### PR TITLE
Add last fetched in shared preferences, reduce timer to 15 minutes

### DIFF
--- a/android/app/src/main/java/app/formstr/calendar/InvitationWorker.java
+++ b/android/app/src/main/java/app/formstr/calendar/InvitationWorker.java
@@ -105,6 +105,10 @@ public class InvitationWorker extends Worker {
                 showNotification(eventIds.size());
             }
 
+            prefs.edit()
+                    .putString(LAST_INVITATION_FETCH_KEY, String.valueOf(System.currentTimeMillis() / 1000))
+                    .apply();
+
             return Result.success();
         } catch (Exception e) {
             Log.e(TAG, "InvitationWorker failed", e);

--- a/android/app/src/main/java/app/formstr/calendar/MainActivity.java
+++ b/android/app/src/main/java/app/formstr/calendar/MainActivity.java
@@ -139,13 +139,13 @@ public class MainActivity extends BridgeActivity {
                 .build();
 
         PeriodicWorkRequest workRequest = new PeriodicWorkRequest.Builder(
-                InvitationWorker.class, 1, TimeUnit.HOURS)
+                InvitationWorker.class, 15, TimeUnit.MINUTES)
                 .setConstraints(constraints)
                 .build();
 
         WorkManager.getInstance(this).enqueueUniquePeriodicWork(
                 INVITATION_WORK_NAME,
-                ExistingPeriodicWorkPolicy.KEEP,
+                ExistingPeriodicWorkPolicy.CANCEL_AND_REENQUEUE,
                 workRequest);
     }
 }


### PR DESCRIPTION
The last fetched wasn't updated from the woerker - fixed it. 
The invitation worker had a cadence of 1 hour which is impractical and can lead to loss of invitations, moved it to 15 minutes