### PR TITLE
feat: allow calendar reassignment from event view (#56)

### DIFF
--- a/src/common/dictionary.ts
+++ b/src/common/dictionary.ts
@@ -89,6 +89,8 @@ const dictionary: NestedObject = {
       eventNotFound: "Event not found. It may not have loaded yet.",
       loadError:
         "We could not load the event. It may be a temporary error. Please refresh the page to try again",
+      calendarMoveError:
+        "We could not move the event to the selected calendar. Please try again.",
       notAuthorized: "You are not allowed to edit this event.",
       notInCalendar:
         "This event is not in any of your calendars. You will not receive notifications for this event. Add it to your calendar to receive notifications.",
@@ -267,6 +269,8 @@ const dictionary: NestedObject = {
         "Termin nicht gefunden. Er wurde möglicherweise noch nicht geladen.",
       loadError:
         "Der Termin konnte nicht geladen werden. Es kann sich um einen vorübergehenden Fehler handeln. Bitte aktualisieren Sie die Seite, um es erneut zu versuchen",
+      calendarMoveError:
+        "Der Termin konnte nicht in den ausgewählten Kalender verschoben werden. Bitte versuchen Sie es erneut.",
       notAuthorized: "Sie sind nicht berechtigt, diesen Termin zu bearbeiten.",
       notInCalendar:
         "Dieser Termin ist in keinem Ihrer Kalender. Sie erhalten keine Benachrichtigungen für diesen Termin. Fügen Sie ihn zu Ihrem Kalender hinzu, um Benachrichtigungen zu erhalten.",

--- a/src/components/CalendarEvent.tsx
+++ b/src/components/CalendarEvent.tsx
@@ -20,7 +20,7 @@ import {
 import { ICalendarEvent } from "../utils/types";
 import { PositionedEvent } from "../common/calendarEngine";
 import { TimeRenderer } from "./TimeRenderer";
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import { Participant } from "./Participant";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -39,13 +39,17 @@ import { useNavigate } from "react-router";
 import { isNative } from "../utils/platform";
 import { useNotifications } from "../stores/notifications";
 import { useCalendarLists } from "../stores/calendarLists";
+import { useTimeBasedEvents } from "../stores/events";
 import { FormattedMessage, useIntl } from "react-intl";
 import { useUser } from "../stores/user";
 import { DeleteEventDialog } from "./DeleteEventDialog";
 import { CalendarListSelect } from "./CalendarListSelect";
 import { useInvitations } from "../stores/invitations";
-import { useTimeBasedEvents } from "../stores/events";
-import { buildEventRef } from "../utils/calendarListTypes";
+import {
+  buildEventRef,
+  getCalendarEventCoordinate,
+} from "../utils/calendarListTypes";
+import { EventCalendarListManagement } from "./EventCalendarListManagement";
 
 interface CalendarEventCardProps {
   event: PositionedEvent;
@@ -361,41 +365,19 @@ export function CalendarEvent({ event }: CalendarEventViewProps) {
   const locations = event.location.filter((location) => !!location?.trim?.());
   const { calendars, moveEventToCalendar } = useCalendarLists();
   const { updateEvent } = useTimeBasedEvents();
-  const [activeCalendarId, setActiveCalendarId] = useState(
-    event.calendarId || "",
-  );
-  const [selectedCalendarId, setSelectedCalendarId] = useState(
-    event.calendarId || "",
-  );
-  const [isEditingCalendar, setIsEditingCalendar] = useState(false);
-  const [savingCalendar, setSavingCalendar] = useState(false);
-  const [calendarEditError, setCalendarEditError] = useState(false);
-  const eventCoordinate = `${event.kind}:${event.user}:${event.id}`;
-  const activeEventCoordinateRef = useRef(eventCoordinate);
+  const eventCoordinate = getCalendarEventCoordinate(event);
 
-  useEffect(() => {
-    activeEventCoordinateRef.current = eventCoordinate;
-    setActiveCalendarId(event.calendarId || "");
-    setSelectedCalendarId(event.calendarId || "");
-    setIsEditingCalendar(false);
-    setSavingCalendar(false);
-    setCalendarEditError(false);
-  }, [eventCoordinate, event.calendarId]);
-
-  const calendar = activeCalendarId
-    ? calendars.find((c) => c.id === activeCalendarId)
+  const calendar = event.calendarId
+    ? calendars.find((c) => c.id === event.calendarId)
     : undefined;
 
-  const handleSaveCalendar = async () => {
-    if (!activeCalendarId || !selectedCalendarId) {
-      return;
-    }
-    if (selectedCalendarId === activeCalendarId) {
-      setIsEditingCalendar(false);
-      return;
+  const handleCalendarUpdate = async (nextCalendarId: string) => {
+    const sourceCalendarId = event.calendarId;
+    if (!sourceCalendarId) {
+      throw new Error("Event is not in any calendar");
     }
 
-    const sourceCalendar = calendars.find((c) => c.id === activeCalendarId);
+    const sourceCalendar = calendars.find((c) => c.id === sourceCalendarId);
     const currentEventRef = sourceCalendar?.eventRefs.find(
       (ref) => ref[0] === eventCoordinate,
     );
@@ -412,33 +394,14 @@ export function CalendarEvent({ event }: CalendarEventViewProps) {
         : undefined);
 
     if (!eventRef) {
-      setCalendarEditError(true);
-      return;
+      throw new Error("Event reference not found");
     }
 
-    const saveEventCoordinate = eventCoordinate;
-    setSavingCalendar(true);
-    setCalendarEditError(false);
-    try {
-      await moveEventToCalendar(selectedCalendarId, eventCoordinate, eventRef);
-      updateEvent({
-        ...event,
-        calendarId: selectedCalendarId,
-      });
-      if (activeEventCoordinateRef.current === saveEventCoordinate) {
-        setActiveCalendarId(selectedCalendarId);
-        setIsEditingCalendar(false);
-      }
-    } catch (error) {
-      if (activeEventCoordinateRef.current === saveEventCoordinate) {
-        setCalendarEditError(true);
-      }
-      console.error("Failed to move event to selected calendar", error);
-    } finally {
-      if (activeEventCoordinateRef.current === saveEventCoordinate) {
-        setSavingCalendar(false);
-      }
-    }
+    await moveEventToCalendar(nextCalendarId, eventCoordinate, eventRef);
+    updateEvent({
+      ...event,
+      calendarId: nextCalendarId,
+    });
   };
 
   return (
@@ -517,87 +480,10 @@ export function CalendarEvent({ event }: CalendarEventViewProps) {
           {calendar ? (
             <>
               <Divider />
-              {isEditingCalendar ? (
-                <Stack spacing={1}>
-                  <Box
-                    display="flex"
-                    alignItems="center"
-                    gap={1}
-                    flexWrap="wrap"
-                  >
-                    <Box maxWidth={500} flex={1} minWidth={150}>
-                      <CalendarListSelect
-                        value={selectedCalendarId}
-                        onChange={setSelectedCalendarId}
-                        size="small"
-                        label={intl.formatMessage({
-                          id: "event.selectCalendar",
-                        })}
-                      />
-                    </Box>
-                    <Button
-                      variant="contained"
-                      size="small"
-                      onClick={handleSaveCalendar}
-                      disabled={
-                        !selectedCalendarId ||
-                        selectedCalendarId === activeCalendarId ||
-                        savingCalendar
-                      }
-                      sx={{ flexShrink: 0, whiteSpace: "nowrap" }}
-                    >
-                      {intl.formatMessage({ id: "navigation.save" })}
-                    </Button>
-                    <Button
-                      variant="text"
-                      size="small"
-                      disabled={savingCalendar}
-                      onClick={() => {
-                        setSelectedCalendarId(activeCalendarId);
-                        setIsEditingCalendar(false);
-                        setCalendarEditError(false);
-                      }}
-                      sx={{ flexShrink: 0, whiteSpace: "nowrap" }}
-                    >
-                      {intl.formatMessage({ id: "navigation.cancel" })}
-                    </Button>
-                  </Box>
-                  {calendarEditError ? (
-                    <Typography variant="caption" color="error">
-                      {intl.formatMessage({ id: "event.calendarMoveError" })}
-                    </Typography>
-                  ) : null}
-                </Stack>
-              ) : (
-                <Box display="flex" alignItems="center" gap={1}>
-                  <Box
-                    sx={{
-                      width: 12,
-                      height: 12,
-                      borderRadius: "50%",
-                      backgroundColor: calendar.color,
-                      flexShrink: 0,
-                    }}
-                  />
-                  <Typography variant="body2">{calendar.title}</Typography>
-                  <Tooltip
-                    title={intl.formatMessage({
-                      id: "calendarManage.editCalendar",
-                    })}
-                  >
-                    <IconButton
-                      size="small"
-                      onClick={() => {
-                        setSelectedCalendarId(activeCalendarId);
-                        setIsEditingCalendar(true);
-                        setCalendarEditError(false);
-                      }}
-                    >
-                      <Edit fontSize="small" />
-                    </IconButton>
-                  </Tooltip>
-                </Box>
-              )}
+              <EventCalendarListManagement
+                calendarId={event.calendarId || ""}
+                onCalendarUpdate={handleCalendarUpdate}
+              />
             </>
           ) : (
             <>

--- a/src/components/CalendarEvent.tsx
+++ b/src/components/CalendarEvent.tsx
@@ -20,7 +20,7 @@ import {
 import { ICalendarEvent } from "../utils/types";
 import { PositionedEvent } from "../common/calendarEngine";
 import { TimeRenderer } from "./TimeRenderer";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Participant } from "./Participant";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -44,6 +44,8 @@ import { useUser } from "../stores/user";
 import { DeleteEventDialog } from "./DeleteEventDialog";
 import { CalendarListSelect } from "./CalendarListSelect";
 import { useInvitations } from "../stores/invitations";
+import { useTimeBasedEvents } from "../stores/events";
+import { buildEventRef } from "../utils/calendarListTypes";
 
 interface CalendarEventCardProps {
   event: PositionedEvent;
@@ -357,10 +359,78 @@ export function CalendarEvent({ event }: CalendarEventViewProps) {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
   const locations = event.location.filter((location) => !!location?.trim?.());
-  const calendars = useCalendarLists.getState().calendars;
-  const calendar = event.calendarId
-    ? calendars.find((c) => c.id === event.calendarId)
+  const { calendars, moveEventToCalendar } = useCalendarLists();
+  const { updateEvent } = useTimeBasedEvents();
+  const [activeCalendarId, setActiveCalendarId] = useState(
+    event.calendarId || "",
+  );
+  const [selectedCalendarId, setSelectedCalendarId] = useState(
+    event.calendarId || "",
+  );
+  const [isEditingCalendar, setIsEditingCalendar] = useState(false);
+  const [savingCalendar, setSavingCalendar] = useState(false);
+  const [calendarEditError, setCalendarEditError] = useState(false);
+
+  useEffect(() => {
+    setActiveCalendarId(event.calendarId || "");
+    setSelectedCalendarId(event.calendarId || "");
+    setIsEditingCalendar(false);
+    setCalendarEditError(false);
+  }, [event.calendarId]);
+
+  const calendar = activeCalendarId
+    ? calendars.find((c) => c.id === activeCalendarId)
     : undefined;
+
+  const handleSaveCalendar = async () => {
+    if (!activeCalendarId || !selectedCalendarId) {
+      return;
+    }
+    if (selectedCalendarId === activeCalendarId) {
+      setIsEditingCalendar(false);
+      return;
+    }
+
+    const eventCoordinate = `${event.kind}:${event.user}:${event.id}`;
+    const sourceCalendar = calendars.find((c) => c.id === activeCalendarId);
+    const currentEventRef = sourceCalendar?.eventRefs.find(
+      (ref) => ref[0] === eventCoordinate,
+    );
+
+    const eventRef =
+      currentEventRef ||
+      (event.viewKey
+        ? buildEventRef({
+            kind: event.kind,
+            authorPubkey: event.user,
+            eventDTag: event.id,
+            viewKey: event.viewKey,
+          })
+        : undefined);
+
+    if (!eventRef) {
+      setCalendarEditError(true);
+      return;
+    }
+
+    setSavingCalendar(true);
+    setCalendarEditError(false);
+    try {
+      await moveEventToCalendar(selectedCalendarId, eventCoordinate, eventRef);
+      setActiveCalendarId(selectedCalendarId);
+      updateEvent({
+        ...event,
+        calendarId: selectedCalendarId,
+      });
+      setIsEditingCalendar(false);
+    } catch (error) {
+      setCalendarEditError(true);
+      console.error("Failed to move event to selected calendar", error);
+    } finally {
+      setSavingCalendar(false);
+    }
+  };
+
   return (
     <Box
       sx={{
@@ -437,18 +507,87 @@ export function CalendarEvent({ event }: CalendarEventViewProps) {
           {calendar ? (
             <>
               <Divider />
-              <Box display="flex" alignItems="center" gap={1}>
-                <Box
-                  sx={{
-                    width: 12,
-                    height: 12,
-                    borderRadius: "50%",
-                    backgroundColor: calendar.color,
-                    flexShrink: 0,
-                  }}
-                />
-                <Typography variant="body2">{calendar.title}</Typography>
-              </Box>
+              {isEditingCalendar ? (
+                <Stack spacing={1}>
+                  <Box
+                    display="flex"
+                    alignItems="center"
+                    gap={1}
+                    flexWrap="wrap"
+                  >
+                    <Box maxWidth={500} flex={1} minWidth={150}>
+                      <CalendarListSelect
+                        value={selectedCalendarId}
+                        onChange={setSelectedCalendarId}
+                        size="small"
+                        label={intl.formatMessage({
+                          id: "event.selectCalendar",
+                        })}
+                      />
+                    </Box>
+                    <Button
+                      variant="contained"
+                      size="small"
+                      onClick={handleSaveCalendar}
+                      disabled={
+                        !selectedCalendarId ||
+                        selectedCalendarId === activeCalendarId ||
+                        savingCalendar
+                      }
+                      sx={{ flexShrink: 0, whiteSpace: "nowrap" }}
+                    >
+                      {intl.formatMessage({ id: "navigation.save" })}
+                    </Button>
+                    <Button
+                      variant="text"
+                      size="small"
+                      disabled={savingCalendar}
+                      onClick={() => {
+                        setSelectedCalendarId(activeCalendarId);
+                        setIsEditingCalendar(false);
+                        setCalendarEditError(false);
+                      }}
+                      sx={{ flexShrink: 0, whiteSpace: "nowrap" }}
+                    >
+                      {intl.formatMessage({ id: "navigation.cancel" })}
+                    </Button>
+                  </Box>
+                  {calendarEditError ? (
+                    <Typography variant="caption" color="error">
+                      {intl.formatMessage({ id: "event.loadError" })}
+                    </Typography>
+                  ) : null}
+                </Stack>
+              ) : (
+                <Box display="flex" alignItems="center" gap={1}>
+                  <Box
+                    sx={{
+                      width: 12,
+                      height: 12,
+                      borderRadius: "50%",
+                      backgroundColor: calendar.color,
+                      flexShrink: 0,
+                    }}
+                  />
+                  <Typography variant="body2">{calendar.title}</Typography>
+                  <Tooltip
+                    title={intl.formatMessage({
+                      id: "calendarManage.editCalendar",
+                    })}
+                  >
+                    <IconButton
+                      size="small"
+                      onClick={() => {
+                        setSelectedCalendarId(activeCalendarId);
+                        setIsEditingCalendar(true);
+                        setCalendarEditError(false);
+                      }}
+                    >
+                      <Edit fontSize="small" />
+                    </IconButton>
+                  </Tooltip>
+                </Box>
+              )}
             </>
           ) : (
             <>

--- a/src/components/CalendarEvent.tsx
+++ b/src/components/CalendarEvent.tsx
@@ -20,7 +20,7 @@ import {
 import { ICalendarEvent } from "../utils/types";
 import { PositionedEvent } from "../common/calendarEngine";
 import { TimeRenderer } from "./TimeRenderer";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Participant } from "./Participant";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -370,13 +370,17 @@ export function CalendarEvent({ event }: CalendarEventViewProps) {
   const [isEditingCalendar, setIsEditingCalendar] = useState(false);
   const [savingCalendar, setSavingCalendar] = useState(false);
   const [calendarEditError, setCalendarEditError] = useState(false);
+  const eventCoordinate = `${event.kind}:${event.user}:${event.id}`;
+  const activeEventCoordinateRef = useRef(eventCoordinate);
 
   useEffect(() => {
+    activeEventCoordinateRef.current = eventCoordinate;
     setActiveCalendarId(event.calendarId || "");
     setSelectedCalendarId(event.calendarId || "");
     setIsEditingCalendar(false);
+    setSavingCalendar(false);
     setCalendarEditError(false);
-  }, [event.calendarId]);
+  }, [eventCoordinate, event.calendarId]);
 
   const calendar = activeCalendarId
     ? calendars.find((c) => c.id === activeCalendarId)
@@ -391,7 +395,6 @@ export function CalendarEvent({ event }: CalendarEventViewProps) {
       return;
     }
 
-    const eventCoordinate = `${event.kind}:${event.user}:${event.id}`;
     const sourceCalendar = calendars.find((c) => c.id === activeCalendarId);
     const currentEventRef = sourceCalendar?.eventRefs.find(
       (ref) => ref[0] === eventCoordinate,
@@ -413,21 +416,28 @@ export function CalendarEvent({ event }: CalendarEventViewProps) {
       return;
     }
 
+    const saveEventCoordinate = eventCoordinate;
     setSavingCalendar(true);
     setCalendarEditError(false);
     try {
       await moveEventToCalendar(selectedCalendarId, eventCoordinate, eventRef);
-      setActiveCalendarId(selectedCalendarId);
       updateEvent({
         ...event,
         calendarId: selectedCalendarId,
       });
-      setIsEditingCalendar(false);
+      if (activeEventCoordinateRef.current === saveEventCoordinate) {
+        setActiveCalendarId(selectedCalendarId);
+        setIsEditingCalendar(false);
+      }
     } catch (error) {
-      setCalendarEditError(true);
+      if (activeEventCoordinateRef.current === saveEventCoordinate) {
+        setCalendarEditError(true);
+      }
       console.error("Failed to move event to selected calendar", error);
     } finally {
-      setSavingCalendar(false);
+      if (activeEventCoordinateRef.current === saveEventCoordinate) {
+        setSavingCalendar(false);
+      }
     }
   };
 
@@ -554,7 +564,7 @@ export function CalendarEvent({ event }: CalendarEventViewProps) {
                   </Box>
                   {calendarEditError ? (
                     <Typography variant="caption" color="error">
-                      {intl.formatMessage({ id: "event.loadError" })}
+                      {intl.formatMessage({ id: "event.calendarMoveError" })}
                     </Typography>
                   ) : null}
                 </Stack>

--- a/src/components/EventCalendarListManagement.tsx
+++ b/src/components/EventCalendarListManagement.tsx
@@ -1,0 +1,151 @@
+import {
+  Box,
+  Button,
+  IconButton,
+  Stack,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import { useEffect, useState } from "react";
+import Edit from "@mui/icons-material/Edit";
+import { useIntl } from "react-intl";
+import { CalendarListSelect } from "./CalendarListSelect";
+import { useCalendarLists } from "../stores/calendarLists";
+
+interface EventCalendarListManagementProps {
+  calendarId: string;
+  onCalendarUpdate: (nextCalendarId: string) => Promise<void>;
+}
+
+export function EventCalendarListManagement({
+  calendarId,
+  onCalendarUpdate,
+}: EventCalendarListManagementProps) {
+  const intl = useIntl();
+  const { calendars } = useCalendarLists();
+  const [selectedCalendarId, setSelectedCalendarId] = useState(calendarId);
+  const [isEditingCalendar, setIsEditingCalendar] = useState(false);
+  const [savingCalendar, setSavingCalendar] = useState(false);
+  const [calendarEditError, setCalendarEditError] = useState(false);
+
+  const calendar = calendars.find((c) => c.id === calendarId);
+
+  useEffect(() => {
+    if (!isEditingCalendar) {
+      setSelectedCalendarId(calendarId);
+    }
+  }, [calendarId, isEditingCalendar]);
+
+  if (!calendar) {
+    return null;
+  }
+
+  const resetUiState = () => {
+    setIsEditingCalendar(false);
+    setSavingCalendar(false);
+    setCalendarEditError(false);
+    setSelectedCalendarId(calendarId);
+  };
+
+  const handleSaveCalendar = async () => {
+    if (!selectedCalendarId) {
+      return;
+    }
+
+    if (selectedCalendarId === calendarId) {
+      resetUiState();
+      return;
+    }
+
+    setSavingCalendar(true);
+    setCalendarEditError(false);
+
+    try {
+      await onCalendarUpdate(selectedCalendarId);
+      setIsEditingCalendar(false);
+      setSavingCalendar(false);
+      setCalendarEditError(false);
+    } catch (error) {
+      setCalendarEditError(true);
+      setSavingCalendar(false);
+      console.error("Failed to move event to selected calendar", error);
+    }
+  };
+
+  if (isEditingCalendar) {
+    return (
+      <Stack spacing={1}>
+        <Box display="flex" alignItems="center" gap={1} flexWrap="wrap">
+          <Box maxWidth={500} flex={1} minWidth={150}>
+            <CalendarListSelect
+              value={selectedCalendarId}
+              onChange={setSelectedCalendarId}
+              size="small"
+              label={intl.formatMessage({
+                id: "event.selectCalendar",
+              })}
+            />
+          </Box>
+          <Button
+            variant="contained"
+            size="small"
+            onClick={handleSaveCalendar}
+            disabled={
+              !selectedCalendarId ||
+              selectedCalendarId === calendarId ||
+              savingCalendar
+            }
+            sx={{ flexShrink: 0, whiteSpace: "nowrap" }}
+          >
+            {intl.formatMessage({ id: "navigation.save" })}
+          </Button>
+          <Button
+            variant="text"
+            size="small"
+            disabled={savingCalendar}
+            onClick={resetUiState}
+            sx={{ flexShrink: 0, whiteSpace: "nowrap" }}
+          >
+            {intl.formatMessage({ id: "navigation.cancel" })}
+          </Button>
+        </Box>
+        {calendarEditError ? (
+          <Typography variant="caption" color="error">
+            {intl.formatMessage({ id: "event.calendarMoveError" })}
+          </Typography>
+        ) : null}
+      </Stack>
+    );
+  }
+
+  return (
+    <Box display="flex" alignItems="center" gap={1}>
+      <Box
+        sx={{
+          width: 12,
+          height: 12,
+          borderRadius: "50%",
+          backgroundColor: calendar.color,
+          flexShrink: 0,
+        }}
+      />
+      <Typography variant="body2">{calendar.title}</Typography>
+      <Tooltip
+        title={intl.formatMessage({
+          id: "calendarManage.editCalendar",
+        })}
+      >
+        <IconButton
+          size="small"
+          onClick={() => {
+            setSelectedCalendarId(calendarId);
+            setIsEditingCalendar(true);
+            setCalendarEditError(false);
+          }}
+        >
+          <Edit fontSize="small" />
+        </IconButton>
+      </Tooltip>
+    </Box>
+  );
+}

--- a/src/utils/calendarListTypes.ts
+++ b/src/utils/calendarListTypes.ts
@@ -1,4 +1,3 @@
-import { EventKinds } from "../common/EventConfigs";
 import type { ICalendarEvent } from "./types";
 
 /**
@@ -117,4 +116,16 @@ export function buildEventRef(params: {
     params.relayUrl || "",
     `${params.viewKey}`,
   ];
+}
+
+/**
+ * Builds the canonical coordinate used in calendar refs and Nostr "a" tags.
+ * Format: "{kind}:{authorPubkey}:{eventDTag}"
+ */
+export function getCalendarEventCoordinate(event: {
+  kind: number;
+  user: string;
+  id: string;
+}): string {
+  return `${event.kind}:${event.user}:${event.id}`;
 }


### PR DESCRIPTION
resolves #56 

**Summary**

- Users can now move an event to a different calendar directly from the event view screen.
- Previously, users who were not the event creator could not reassign an event after adding it to their calendar.

**Changes Made**

- Added an Edit action next to the current calendar on the event view.
- Clicking Edit shows an inline calendar selector with Save and Cancel actions.
- Save moves the event to the selected calendar and updates local event state immediately.
- Added loading and error handling states for the save flow.
- Kept existing event edit permissions unchanged for full event content editing.

**Testing**

- Verified production build succeeds.
- Manually validated:
  -  Open an event already assigned to a calendar.
  -  Click Edit next to the calendar.
  -  Select a different calendar and click Save.
  -  Confirm event is reassigned and UI reflects the new calendar.
  -  Confirm Cancel exits edit mode without changes.
  -  Notes

(Repository currently has pre-existing lint/test failures unrelated to this PR.)