### PR TITLE
feat: implement Nostr-native event comments using kind 1 text notes

### DIFF
--- a/src/common/EventConfigs.ts
+++ b/src/common/EventConfigs.ts
@@ -21,6 +21,9 @@ export enum EventKinds {
   // Participant Removal (kind 84 - participant opts out of an event)
   ParticipantRemoval = 84,
 
+  // Text Note (Comments/Replies)
+  TextNote = 1,
+
   // Relay List (NIP-65)
   RelayList = 10002,
 }

--- a/src/common/nostr.ts
+++ b/src/common/nostr.ts
@@ -825,3 +825,38 @@ export const publishRelayList = async (relays: string[]): Promise<void> => {
   const allRelays = [...new Set([...relays, ...defaultRelays])];
   await publishToRelays(fullEvent, () => {}, allRelays);
 };
+
+export const fetchEventComments = (
+  aTagString: string,
+  onEvent: (event: Event) => void,
+) => {
+  const relayList = getRelays();
+  const filter: Filter = {
+    kinds: [EventKinds.TextNote],
+    "#a": [aTagString],
+  };
+
+  return nostrRuntime.subscribe(relayList, [filter], {
+    onEvent: (event: Event) => {
+      onEvent(event);
+    },
+  });
+};
+
+export const publishEventComment = async (
+  aTagString: string,
+  content: string,
+) => {
+  const pubKey = await getUserPublicKey();
+  const baseEvent: UnsignedEvent = {
+    kind: EventKinds.TextNote,
+    pubkey: pubKey,
+    tags: [["a", aTagString]],
+    content: content,
+    created_at: Math.floor(Date.now() / 1000),
+  };
+  const signer = await signerManager.getSigner();
+  const fullEvent = await signer.signEvent(baseEvent);
+  fullEvent.id = getEventHash(baseEvent);
+  return publishToRelays(fullEvent);
+};

--- a/src/components/CalendarEvent.tsx
+++ b/src/components/CalendarEvent.tsx
@@ -44,6 +44,7 @@ import { useUser } from "../stores/user";
 import { DeleteEventDialog } from "./DeleteEventDialog";
 import { CalendarListSelect } from "./CalendarListSelect";
 import { useInvitations } from "../stores/invitations";
+import { EventComments } from "./EventComments";
 
 interface CalendarEventCardProps {
   event: PositionedEvent;
@@ -458,6 +459,10 @@ export function CalendarEvent({ event }: CalendarEventViewProps) {
           )}
 
           <ScheduledNotificationsSection eventId={event.id} />
+          
+          {/* Comments Section */}
+          <Divider />
+          <EventComments event={event} />
         </Stack>
       </Box>
     </Box>

--- a/src/components/EventComments.tsx
+++ b/src/components/EventComments.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useState } from "react";
+import { Box, Button, CircularProgress, Stack, TextField, Typography, Paper, Divider } from "@mui/material";
+import { Event } from "nostr-tools";
+import { useIntl } from "react-intl";
+import { ICalendarEvent } from "../utils/types";
+import { fetchEventComments, publishEventComment } from "../common/nostr";
+import { useUser } from "../stores/user";
+import { Participant } from "./Participant";
+
+interface EventCommentsProps {
+  event: ICalendarEvent;
+}
+
+export function EventComments({ event }: EventCommentsProps) {
+  const intl = useIntl();
+  const { user } = useUser();
+  const [comments, setComments] = useState<Event[]>([]);
+  const [newComment, setNewComment] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+
+  // Derive the a-tag coordinate: "<kind>:<pubkey>:<d-identifier>"
+  const aTagString = `${event.kind}:${event.user}:${event.id}`;
+
+  useEffect(() => {
+    let mounted = true;
+    setIsLoading(true);
+    setComments([]);
+
+    // Open subscription
+    const sub = fetchEventComments(aTagString, (fetchedEvent) => {
+      if (mounted) {
+        setComments((prev) => {
+          // Prevent duplicates
+          if (prev.find((c) => c.id === fetchedEvent.id)) return prev;
+          // Return newly sorted array (oldest first)
+          return [...prev, fetchedEvent].sort((a, b) => a.created_at - b.created_at);
+        });
+      }
+    });
+
+    // We consider loading finished quickly after init
+    const timeout = setTimeout(() => {
+      if (mounted) setIsLoading(false);
+    }, 1500);
+
+    return () => {
+      mounted = false;
+      sub.unsubscribe();
+      clearTimeout(timeout);
+    };
+  }, [aTagString]);
+
+  const handleSubmit = async () => {
+    if (!newComment.trim() || !user) return;
+    setIsSubmitting(true);
+    try {
+      await publishEventComment(aTagString, newComment.trim());
+      setNewComment("");
+    } catch (e) {
+      console.error("Failed to post comment:", e);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Box mt={4} mb={2}>
+      <Typography variant="h6" gutterBottom>
+        {intl.formatMessage({ id: "comments.title", defaultMessage: "Comments" })}
+      </Typography>
+
+      <Paper variant="outlined" sx={{ p: 2, minHeight: 100 }}>
+        {isLoading && comments.length === 0 ? (
+          <Box display="flex" justifyContent="center" p={2}>
+            <CircularProgress size={24} />
+          </Box>
+        ) : comments.length === 0 ? (
+          <Typography variant="body2" color="text.secondary" p={2} textAlign="center">
+            {intl.formatMessage({ id: "comments.empty", defaultMessage: "No comments yet. Be the first to add one!" })}
+          </Typography>
+        ) : (
+          <Stack spacing={2} divider={<Divider />}>
+            {comments.map((comment) => (
+              <Box key={comment.id}>
+                <Box mb={1}>
+                  <Participant pubKey={comment.pubkey} isAuthor={comment.pubkey === event.user} />
+                </Box>
+                <Typography variant="body2" sx={{ whiteSpace: "pre-wrap" }}>
+                  {comment.content}
+                </Typography>
+                <Typography variant="caption" color="text.secondary" display="block" mt={0.5}>
+                  {new Date(comment.created_at * 1000).toLocaleString()}
+                </Typography>
+              </Box>
+            ))}
+          </Stack>
+        )}
+
+        {user ? (
+          <Box pt={3}>
+            <Stack spacing={1}>
+              <TextField
+                multiline
+                rows={2}
+                fullWidth
+                size="small"
+                placeholder={intl.formatMessage({ id: "comments.placeholder", defaultMessage: "Add a comment..." })}
+                value={newComment}
+                onChange={(e) => setNewComment(e.target.value)}
+                disabled={isSubmitting}
+              />
+              <Box display="flex" justifyContent="flex-end">
+                <Button
+                  variant="contained"
+                  disabled={!newComment.trim() || isSubmitting}
+                  onClick={handleSubmit}
+                  size="small"
+                >
+                  {isSubmitting
+                    ? intl.formatMessage({ id: "comments.posting", defaultMessage: "Posting..." })
+                    : intl.formatMessage({ id: "comments.post", defaultMessage: "Post Comment" })}
+                </Button>
+              </Box>
+            </Stack>
+          </Box>
+        ) : (
+          <Box pt={2}>
+            <Typography variant="body2" color="text.secondary" textAlign="center">
+              {intl.formatMessage({ id: "comments.loginPrompt", defaultMessage: "Please log in to add a comment." })}
+            </Typography>
+          </Box>
+        )}
+      </Paper>
+    </Box>
+  );
+}


### PR DESCRIPTION
### Summary

Adds support for commenting on calendar events using standard Nostr text notes (kind 1). Users can now view and post comments directly on an event, making it easier to discuss and collaborate.


### Changes
- Added support for fetching and publishing event comments (kind 1, tied to event a-tag)
- Introduced an EventComments component to display and post comments
- Reused existing UI (e.g. Participant) for consistency
- Integrated comments section into the event view


### Behavior
- Logged-in users can post comments
- Guests can view comments but are prompted to log in to participate
- Comments load and display in chronological order

fixs:#73