### PR TITLE
feat:add list-level notification preferences 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -148,8 +148,14 @@ function Application() {
     title: string;
     description: string;
     color: string;
+    notificationPreference: "enabled" | "disabled";
   }) => {
-    await createCalendar(data.title, data.description, data.color);
+    await createCalendar(
+      data.title,
+      data.description,
+      data.color,
+      data.notificationPreference,
+    );
     setShowOnboardingDialog(false);
   };
 

--- a/src/common/calendarList.test.ts
+++ b/src/common/calendarList.test.ts
@@ -72,7 +72,6 @@ const makeCalendar = (overrides?: Partial<ICalendarList>): ICalendarList => ({
   title: "My Calendar",
   description: "Personal events",
   color: "#4285f4",
-  notificationPreference: "enabled",
   eventRefs: [
     ["32678:testpubkey:event-1", "", "nsec1key:1700000000::1700003600:false"],
   ],
@@ -98,7 +97,7 @@ describe("calendarList protocol layer", () => {
       expect(tags).toContainEqual(["title", "My Calendar"]);
       expect(tags).toContainEqual(["content", "Personal events"]);
       expect(tags).toContainEqual(["color", "#4285f4"]);
-      expect(tags).toContainEqual(["notifications", "enabled"]);
+      expect(tags).not.toContainEqual(["notifications", "enabled"]);
       expect(tags).toContainEqual([
         "a",
         "32678:testpubkey:event-1",
@@ -130,6 +129,14 @@ describe("calendarList protocol layer", () => {
       const tags = JSON.parse(mockEncrypt.mock.calls[0][1]);
       const aTags = tags.filter((t: string[]) => t[0] === "a");
       expect(aTags).toHaveLength(3);
+    });
+
+    it("stores notification preference only when non-default", async () => {
+      const cal = makeCalendar({ notificationPreference: "disabled" });
+      await encryptCalendarList(cal);
+
+      const tags = JSON.parse(mockEncrypt.mock.calls[0][1]);
+      expect(tags).toContainEqual(["notifications", "disabled"]);
     });
 
     it("handles empty eventRefs", async () => {
@@ -194,7 +201,7 @@ describe("calendarList protocol layer", () => {
       expect(result.title).toBe("Minimal");
       expect(result.description).toBe("");
       expect(result.color).toBe("#4285f4"); // default color
-      expect(result.notificationPreference).toBe("enabled");
+      expect(result.notificationPreference).toBeUndefined();
       expect(result.eventRefs).toEqual([]);
     });
 

--- a/src/common/calendarList.test.ts
+++ b/src/common/calendarList.test.ts
@@ -16,6 +16,7 @@ const { mockEncrypt, mockDecrypt, mockSignEvent } = vi.hoisted(() => ({
       ["title", "Test Calendar"],
       ["content", "A test calendar"],
       ["color", "#d50000"],
+      ["notifications", "disabled"],
       [
         "a",
         "32678:testpubkey:event-1",
@@ -71,6 +72,7 @@ const makeCalendar = (overrides?: Partial<ICalendarList>): ICalendarList => ({
   title: "My Calendar",
   description: "Personal events",
   color: "#4285f4",
+  notificationPreference: "enabled",
   eventRefs: [
     ["32678:testpubkey:event-1", "", "nsec1key:1700000000::1700003600:false"],
   ],
@@ -96,6 +98,7 @@ describe("calendarList protocol layer", () => {
       expect(tags).toContainEqual(["title", "My Calendar"]);
       expect(tags).toContainEqual(["content", "Personal events"]);
       expect(tags).toContainEqual(["color", "#4285f4"]);
+      expect(tags).toContainEqual(["notifications", "enabled"]);
       expect(tags).toContainEqual([
         "a",
         "32678:testpubkey:event-1",
@@ -157,6 +160,7 @@ describe("calendarList protocol layer", () => {
       expect(result.title).toBe("Test Calendar");
       expect(result.description).toBe("A test calendar");
       expect(result.color).toBe("#d50000");
+      expect(result.notificationPreference).toBe("disabled");
       expect(result.eventRefs).toEqual([
         [
           "32678:testpubkey:event-1",
@@ -190,6 +194,7 @@ describe("calendarList protocol layer", () => {
       expect(result.title).toBe("Minimal");
       expect(result.description).toBe("");
       expect(result.color).toBe("#4285f4"); // default color
+      expect(result.notificationPreference).toBe("enabled");
       expect(result.eventRefs).toEqual([]);
     });
 

--- a/src/common/calendarList.ts
+++ b/src/common/calendarList.ts
@@ -34,7 +34,6 @@ import type { ICalendarList } from "../utils/calendarListTypes";
 import {
   DEFAULT_CALENDAR_COLOR,
   DEFAULT_CALENDAR_TITLE,
-  DEFAULT_NOTIFICATION_PREFERENCE,
 } from "../utils/calendarListTypes";
 import type { SubscriptionHandle } from "./nostrRuntime";
 
@@ -52,11 +51,12 @@ export async function encryptCalendarList(
     ["title", calendarList.title],
     ["content", calendarList.description],
     ["color", calendarList.color],
-    [
-      "notifications",
-      calendarList.notificationPreference ?? DEFAULT_NOTIFICATION_PREFERENCE,
-    ],
   ];
+
+  // Persist only non-default notification preference to minimize relay payload.
+  if (calendarList.notificationPreference === "disabled") {
+    tags.push(["notifications", "disabled"]);
+  }
 
   // Add event references as "a" tags: ["a", coordinate, metadata]
   for (const ref of calendarList.eventRefs) {
@@ -96,7 +96,7 @@ export async function decryptCalendarList(
   let title = DEFAULT_CALENDAR_TITLE;
   let description = "";
   let color = DEFAULT_CALENDAR_COLOR;
-  let notificationPreference = DEFAULT_NOTIFICATION_PREFERENCE;
+  let notificationPreference: "enabled" | "disabled" | undefined;
   const eventRefs: string[][] = [];
 
   for (const tag of tags) {
@@ -111,8 +111,7 @@ export async function decryptCalendarList(
         color = tag[1] || DEFAULT_CALENDAR_COLOR;
         break;
       case "notifications":
-        notificationPreference =
-          tag[1] === "disabled" ? "disabled" : DEFAULT_NOTIFICATION_PREFERENCE;
+        notificationPreference = tag[1] === "disabled" ? "disabled" : "enabled";
         break;
       case "a":
         // a-tag format: ["a", "{kind}:{authorPubkey}:{eventDTag}", "{relayUrl}", "{viewKey}:{beginTimeSecs}::{endTimeSecs}:{isRecurring}"]
@@ -231,7 +230,6 @@ export async function createDefaultCalendar(): Promise<ICalendarList> {
     title: DEFAULT_CALENDAR_TITLE,
     description: "",
     color: DEFAULT_CALENDAR_COLOR,
-    notificationPreference: DEFAULT_NOTIFICATION_PREFERENCE,
     eventId: "",
     eventRefs: [],
     isVisible: true,

--- a/src/common/calendarList.ts
+++ b/src/common/calendarList.ts
@@ -34,6 +34,7 @@ import type { ICalendarList } from "../utils/calendarListTypes";
 import {
   DEFAULT_CALENDAR_COLOR,
   DEFAULT_CALENDAR_TITLE,
+  DEFAULT_NOTIFICATION_PREFERENCE,
 } from "../utils/calendarListTypes";
 import type { SubscriptionHandle } from "./nostrRuntime";
 
@@ -51,6 +52,10 @@ export async function encryptCalendarList(
     ["title", calendarList.title],
     ["content", calendarList.description],
     ["color", calendarList.color],
+    [
+      "notifications",
+      calendarList.notificationPreference ?? DEFAULT_NOTIFICATION_PREFERENCE,
+    ],
   ];
 
   // Add event references as "a" tags: ["a", coordinate, metadata]
@@ -91,6 +96,7 @@ export async function decryptCalendarList(
   let title = DEFAULT_CALENDAR_TITLE;
   let description = "";
   let color = DEFAULT_CALENDAR_COLOR;
+  let notificationPreference = DEFAULT_NOTIFICATION_PREFERENCE;
   const eventRefs: string[][] = [];
 
   for (const tag of tags) {
@@ -103,6 +109,10 @@ export async function decryptCalendarList(
         break;
       case "color":
         color = tag[1] || DEFAULT_CALENDAR_COLOR;
+        break;
+      case "notifications":
+        notificationPreference =
+          tag[1] === "disabled" ? "disabled" : DEFAULT_NOTIFICATION_PREFERENCE;
         break;
       case "a":
         // a-tag format: ["a", "{kind}:{authorPubkey}:{eventDTag}", "{relayUrl}", "{viewKey}:{beginTimeSecs}::{endTimeSecs}:{isRecurring}"]
@@ -120,6 +130,7 @@ export async function decryptCalendarList(
     title,
     description,
     color,
+    notificationPreference,
     eventRefs,
     createdAt: event.created_at,
     isVisible: true, // Default to visible; client-side state
@@ -220,6 +231,7 @@ export async function createDefaultCalendar(): Promise<ICalendarList> {
     title: DEFAULT_CALENDAR_TITLE,
     description: "",
     color: DEFAULT_CALENDAR_COLOR,
+    notificationPreference: DEFAULT_NOTIFICATION_PREFERENCE,
     eventId: "",
     eventRefs: [],
     isVisible: true,

--- a/src/common/dictionary.ts
+++ b/src/common/dictionary.ts
@@ -123,6 +123,9 @@ const dictionary: NestedObject = {
       calendarNamePlaceholder: "e.g., Work, Personal, Travel",
       optionalDescription: "Optional description",
       color: "Color",
+      notifications: "Notifications",
+      notificationsOn: "Enabled for this calendar",
+      notificationsOff: "Disabled for this calendar",
       onboardingExplanation:
         "Create a calendar to get started. Events are organized into calendars — you need at least one to add and manage your events.",
       refetchCalendars: "Refetch Calendars",
@@ -309,6 +312,9 @@ const dictionary: NestedObject = {
       calendarNamePlaceholder: "z.B. Arbeit, Persönlich, Reise",
       optionalDescription: "Optionale Beschreibung",
       color: "Farbe",
+      notifications: "Benachrichtigungen",
+      notificationsOn: "Für diesen Kalender aktiviert",
+      notificationsOff: "Für diesen Kalender deaktiviert",
       onboardingExplanation:
         "Erstellen Sie einen Kalender, um loszulegen. Termine werden in Kalendern organisiert — Sie benötigen mindestens einen, um Termine hinzuzufügen und zu verwalten.",
       refetchCalendars: "Kalender neu laden",
@@ -373,3 +379,5 @@ const dictionary: NestedObject = {
   },
 };
 export default dictionary;
+
+

--- a/src/common/dictionary.ts
+++ b/src/common/dictionary.ts
@@ -126,6 +126,7 @@ const dictionary: NestedObject = {
       notifications: "Notifications",
       notificationsOn: "Enabled for this calendar",
       notificationsOff: "Disabled for this calendar",
+      notificationsAppOnly: "Notifications are only available in the app.",
       onboardingExplanation:
         "Create a calendar to get started. Events are organized into calendars — you need at least one to add and manage your events.",
       refetchCalendars: "Refetch Calendars",
@@ -315,6 +316,7 @@ const dictionary: NestedObject = {
       notifications: "Benachrichtigungen",
       notificationsOn: "Für diesen Kalender aktiviert",
       notificationsOff: "Für diesen Kalender deaktiviert",
+      notificationsAppOnly: "Benachrichtigungen sind nur in der App verfügbar.",
       onboardingExplanation:
         "Erstellen Sie einen Kalender, um loszulegen. Termine werden in Kalendern organisiert — Sie benötigen mindestens einen, um Termine hinzuzufügen und zu verwalten.",
       refetchCalendars: "Kalender neu laden",
@@ -379,5 +381,7 @@ const dictionary: NestedObject = {
   },
 };
 export default dictionary;
+
+
 
 

--- a/src/common/nostr.ts
+++ b/src/common/nostr.ts
@@ -641,9 +641,6 @@ export const publishPublicCalendarEvent = async (
     ["start", String(Math.floor(event.begin / 1000))],
     ["end", String(Math.floor(event.end / 1000))],
   ];
-  if (event.notificationPreference) {
-    tags.push(["notification", event.notificationPreference]);
-  }
   if (event.image) {
     tags.push(["image", event.image]);
   }

--- a/src/common/nostr.ts
+++ b/src/common/nostr.ts
@@ -233,6 +233,9 @@ async function preparePrivateCalendarEvent(
     eventData.push(["L", "rrule"]);
     eventData.push(["l", event.repeat.rrule]);
   }
+  if (event.notificationPreference) {
+    eventData.push(["notification", event.notificationPreference]);
+  }
 
   event.location.forEach((loc) => {
     eventData.push(["location", loc]);
@@ -638,6 +641,9 @@ export const publishPublicCalendarEvent = async (
     ["start", String(Math.floor(event.begin / 1000))],
     ["end", String(Math.floor(event.end / 1000))],
   ];
+  if (event.notificationPreference) {
+    tags.push(["notification", event.notificationPreference]);
+  }
   if (event.image) {
     tags.push(["image", event.image]);
   }

--- a/src/components/CalendarListSelect.tsx
+++ b/src/components/CalendarListSelect.tsx
@@ -49,11 +49,13 @@ export function CalendarListSelect({
     title: string;
     description: string;
     color: string;
+    notificationPreference: "enabled" | "disabled";
   }) => {
     const newCalendar = await createCalendar(
       data.title,
       data.description,
       data.color,
+      data.notificationPreference,
     );
     if (newCalendar) {
       onChange(newCalendar.id);

--- a/src/components/CalendarManageDialog.tsx
+++ b/src/components/CalendarManageDialog.tsx
@@ -19,7 +19,10 @@ import {
 import RefreshIcon from "@mui/icons-material/Refresh";
 import CloseIcon from "@mui/icons-material/Close";
 import CircleIcon from "@mui/icons-material/Circle";
-import type { ICalendarList } from "../utils/calendarListTypes";
+import {
+  DEFAULT_NOTIFICATION_PREFERENCE,
+  type ICalendarList,
+} from "../utils/calendarListTypes";
 import { useIntl } from "react-intl";
 import type { NotificationPreference } from "../utils/types";
 
@@ -67,7 +70,7 @@ export function CalendarManageDialog({
   const [color, setColor] = useState(calendar?.color || PRESET_COLORS[0]);
   const [notificationPreference, setNotificationPreference] =
     useState<NotificationPreference>(
-      calendar?.notificationPreference || "enabled",
+      calendar?.notificationPreference ?? DEFAULT_NOTIFICATION_PREFERENCE,
     );
   const intl = useIntl();
   const theme = useTheme();

--- a/src/components/CalendarManageDialog.tsx
+++ b/src/components/CalendarManageDialog.tsx
@@ -9,6 +9,10 @@ import {
   Box,
   Typography,
   IconButton,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
   useMediaQuery,
   useTheme,
 } from "@mui/material";
@@ -17,6 +21,7 @@ import CloseIcon from "@mui/icons-material/Close";
 import CircleIcon from "@mui/icons-material/Circle";
 import type { ICalendarList } from "../utils/calendarListTypes";
 import { useIntl } from "react-intl";
+import type { NotificationPreference } from "../utils/types";
 
 const PRESET_COLORS = [
   "#4285f4", // Blue
@@ -35,7 +40,12 @@ interface CalendarManageDialogProps {
   open: boolean;
   onClose: () => void;
   calendar?: ICalendarList;
-  onSave: (data: { title: string; description: string; color: string }) => void;
+  onSave: (data: {
+    title: string;
+    description: string;
+    color: string;
+    notificationPreference: NotificationPreference;
+  }) => void;
   onDelete?: () => void;
   /** When true, the dialog cannot be dismissed — used for onboarding when no calendars exist. */
   blocking?: boolean;
@@ -55,13 +65,22 @@ export function CalendarManageDialog({
   const [title, setTitle] = useState(calendar?.title || "");
   const [description, setDescription] = useState(calendar?.description || "");
   const [color, setColor] = useState(calendar?.color || PRESET_COLORS[0]);
+  const [notificationPreference, setNotificationPreference] =
+    useState<NotificationPreference>(
+      calendar?.notificationPreference || "enabled",
+    );
   const intl = useIntl();
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
 
   const handleSave = () => {
     if (!title.trim()) return;
-    onSave({ title: title.trim(), description: description.trim(), color });
+    onSave({
+      title: title.trim(),
+      description: description.trim(),
+      color,
+      notificationPreference,
+    });
     onClose();
   };
 
@@ -162,6 +181,29 @@ export function CalendarManageDialog({
               ))}
             </Box>
           </Box>
+
+          <FormControl size="small" fullWidth>
+            <InputLabel id="calendar-notifications-label">
+              {intl.formatMessage({ id: "calendarManage.notifications" })}
+            </InputLabel>
+            <Select
+              labelId="calendar-notifications-label"
+              label={intl.formatMessage({ id: "calendarManage.notifications" })}
+              value={notificationPreference}
+              onChange={(e) =>
+                setNotificationPreference(
+                  e.target.value as NotificationPreference,
+                )
+              }
+            >
+              <MenuItem value="enabled">
+                {intl.formatMessage({ id: "calendarManage.notificationsOn" })}
+              </MenuItem>
+              <MenuItem value="disabled">
+                {intl.formatMessage({ id: "calendarManage.notificationsOff" })}
+              </MenuItem>
+            </Select>
+          </FormControl>
         </Box>
       </DialogContent>
 

--- a/src/components/CalendarSidebar.tsx
+++ b/src/components/CalendarSidebar.tsx
@@ -28,7 +28,10 @@ import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import { DatePicker } from "./DatePicker";
 import { useCalendarLists } from "../stores/calendarLists";
 import { CalendarManageDialog } from "./CalendarManageDialog";
-import type { ICalendarList } from "../utils/calendarListTypes";
+import {
+  DEFAULT_NOTIFICATION_PREFERENCE,
+  type ICalendarList,
+} from "../utils/calendarListTypes";
 import { useIntl } from "react-intl";
 import { useTimeBasedEvents } from "../stores/events";
 
@@ -71,7 +74,8 @@ export function CalendarSidebar({ onClose }: CalendarSidebarProps) {
   }) => {
     if (editingCalendar) {
       const preferenceChanged =
-        (editingCalendar.notificationPreference || "enabled") !==
+        (editingCalendar.notificationPreference ??
+          DEFAULT_NOTIFICATION_PREFERENCE) !==
         data.notificationPreference;
 
       await updateCalendar({ ...editingCalendar, ...data });

--- a/src/components/CalendarSidebar.tsx
+++ b/src/components/CalendarSidebar.tsx
@@ -28,6 +28,7 @@ import { useCalendarLists } from "../stores/calendarLists";
 import { CalendarManageDialog } from "./CalendarManageDialog";
 import type { ICalendarList } from "../utils/calendarListTypes";
 import { useIntl } from "react-intl";
+import { useTimeBasedEvents } from "../stores/events";
 
 interface CalendarSidebarProps {
   onClose: () => void;
@@ -64,11 +65,26 @@ export function CalendarSidebar({ onClose }: CalendarSidebarProps) {
     title: string;
     description: string;
     color: string;
+    notificationPreference: "enabled" | "disabled";
   }) => {
     if (editingCalendar) {
+      const preferenceChanged =
+        (editingCalendar.notificationPreference || "enabled") !==
+        data.notificationPreference;
+
       await updateCalendar({ ...editingCalendar, ...data });
+      if (preferenceChanged) {
+        useTimeBasedEvents
+          .getState()
+          .refreshNotificationPreferencesForCalendar(editingCalendar.id);
+      }
     } else {
-      await createCalendar(data.title, data.description, data.color);
+      await createCalendar(
+        data.title,
+        data.description,
+        data.color,
+        data.notificationPreference,
+      );
     }
   };
 

--- a/src/components/CalendarSidebar.tsx
+++ b/src/components/CalendarSidebar.tsx
@@ -17,12 +17,14 @@ import {
   Typography,
   IconButton,
   Button,
+  Tooltip,
   useMediaQuery,
   useTheme,
 } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
 import AddIcon from "@mui/icons-material/Add";
 import CircleIcon from "@mui/icons-material/Circle";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import { DatePicker } from "./DatePicker";
 import { useCalendarLists } from "../stores/calendarLists";
 import { CalendarManageDialog } from "./CalendarManageDialog";
@@ -115,9 +117,21 @@ export function CalendarSidebar({ onClose }: CalendarSidebarProps) {
           alignItems="center"
           mb={1}
         >
-          <Typography variant="subtitle2" fontWeight={600}>
-            {intl.formatMessage({ id: "sidebar.calendars" })}
-          </Typography>
+          <Box display="flex" alignItems="center" gap={0.5}>
+            <Typography variant="subtitle2" fontWeight={600}>
+              {intl.formatMessage({ id: "sidebar.calendars" })}
+            </Typography>
+            <Tooltip
+              title={intl.formatMessage({
+                id: "calendarManage.notificationsAppOnly",
+              })}
+              arrow
+            >
+              <InfoOutlinedIcon
+                sx={{ fontSize: 16, color: "text.secondary", cursor: "help" }}
+              />
+            </Tooltip>
+          </Box>
           <IconButton size="small" onClick={handleCreateCalendar}>
             <AddIcon fontSize="small" />
           </IconButton>

--- a/src/stores/calendarLists.test.ts
+++ b/src/stores/calendarLists.test.ts
@@ -6,17 +6,40 @@ vi.mock("../common/localStorage", () => ({
   getSecureItem: vi.fn().mockResolvedValue([]),
   setSecureItem: vi.fn(),
   removeSecureItem: vi.fn(),
+  setItem: vi.fn(),
+  getItem: vi.fn().mockReturnValue({}),
 }));
 
 // Mock calendarList protocol layer
 vi.mock("../common/calendarList", () => ({
   fetchCalendarLists: vi.fn().mockReturnValue({ unsubscribe: vi.fn() }),
   publishCalendarList: vi.fn().mockResolvedValue({}),
+  createCalendar: vi
+    .fn()
+    .mockImplementation(
+      async ({
+        title,
+        description,
+        color,
+        notificationPreference = "enabled",
+      }) => ({
+        id: `cal-${title.toLowerCase()}`,
+        eventId: "event-id",
+        title,
+        description,
+        color,
+        notificationPreference,
+        eventRefs: [],
+        createdAt: Math.floor(Date.now() / 1000),
+        isVisible: true,
+      }),
+    ),
   createDefaultCalendar: vi.fn().mockResolvedValue({
     id: "default-cal-id",
     title: "My Calendar",
     description: "",
     color: "#4285f4",
+    notificationPreference: "enabled",
     eventRefs: [],
     createdAt: 1700000000,
     isVisible: true,
@@ -39,6 +62,7 @@ vi.mock("../common/nostr", () => ({
   getUserPublicKey: vi.fn().mockResolvedValue("test-pubkey-" + "0".repeat(50)),
   getRelays: vi.fn().mockReturnValue(["wss://relay.test"]),
   publishToRelays: vi.fn().mockResolvedValue("ok"),
+  publishDeletionEvent: vi.fn().mockResolvedValue({}),
 }));
 
 describe("useCalendarLists store", () => {
@@ -68,6 +92,7 @@ describe("useCalendarLists store", () => {
     expect(calendars[0].color).toBe("#d50000");
     expect(calendars[0].isVisible).toBe(true);
     expect(calendars[0].eventRefs).toEqual([]);
+    expect(calendars[0].notificationPreference).toBe("enabled");
     expect(calendars[0].id).toBeTruthy();
   });
 

--- a/src/stores/calendarLists.ts
+++ b/src/stores/calendarLists.ts
@@ -63,6 +63,12 @@ const withNotificationPreference = (calendar: ICalendarList): ICalendarList => (
     calendar.notificationPreference ?? DEFAULT_NOTIFICATION_PREFERENCE,
 });
 
+const normalizePreferenceForPublish = (
+  preference?: "enabled" | "disabled",
+): "disabled" | undefined => {
+  return preference === "disabled" ? "disabled" : undefined;
+};
+
 interface CalendarListsState {
   calendars: ICalendarList[];
   isLoaded: boolean;
@@ -217,37 +223,44 @@ export const useCalendarLists = create<CalendarListsState>((set, get) => ({
       title,
       description,
       color,
-      notificationPreference,
+      notificationPreference: normalizePreferenceForPublish(
+        notificationPreference,
+      ),
       eventId: "",
       eventRefs: [],
       isVisible: true,
     });
+    const calendarWithDefaults = withNotificationPreference(newCalendar);
 
     set((state) => {
-      const updated = [...state.calendars, newCalendar];
+      const updated = [...state.calendars, calendarWithDefaults];
       saveCalendarsToStorage(updated);
       return { calendars: updated };
     });
 
-    return newCalendar;
+    return calendarWithDefaults;
   },
 
   /**
    * Updates calendar metadata (title, description, color) and republishes.
    */
   updateCalendar: async (calendar) => {
-    const updated = {
+    const updatedForPublish = {
       ...calendar,
-      notificationPreference:
-        calendar.notificationPreference ?? DEFAULT_NOTIFICATION_PREFERENCE,
+      notificationPreference: normalizePreferenceForPublish(
+        calendar.notificationPreference,
+      ),
       createdAt: Math.floor(Date.now() / 1000),
     };
-    const publishedEvent = await publishCalendarList(updated);
-    updated.eventId = publishedEvent.id;
+    const publishedEvent = await publishCalendarList(updatedForPublish);
+    const updatedForState = withNotificationPreference({
+      ...updatedForPublish,
+      eventId: publishedEvent.id,
+    });
 
     set((state) => {
       const calendars = state.calendars.map((c) =>
-        c.id === calendar.id ? updated : c,
+        c.id === calendar.id ? updatedForState : c,
       );
       saveCalendarsToStorage(calendars);
       return { calendars };

--- a/src/stores/calendarLists.ts
+++ b/src/stores/calendarLists.ts
@@ -30,7 +30,10 @@ import {
 } from "../common/calendarList";
 import { getUserPublicKey, publishDeletionEvent } from "../common/nostr";
 import { EventKinds } from "../common/EventConfigs";
-import type { ICalendarList } from "../utils/calendarListTypes";
+import {
+  DEFAULT_NOTIFICATION_PREFERENCE,
+  type ICalendarList,
+} from "../utils/calendarListTypes";
 import type { SubscriptionHandle } from "../common/nostrRuntime";
 import { isNative } from "../utils/platform";
 
@@ -54,6 +57,12 @@ const saveVisibilityToStorage = (visibility: Record<string, boolean>) => {
 
 let subscriptionHandle: SubscriptionHandle | undefined;
 
+const withNotificationPreference = (calendar: ICalendarList): ICalendarList => ({
+  ...calendar,
+  notificationPreference:
+    calendar.notificationPreference ?? DEFAULT_NOTIFICATION_PREFERENCE,
+});
+
 interface CalendarListsState {
   calendars: ICalendarList[];
   isLoaded: boolean;
@@ -64,6 +73,7 @@ interface CalendarListsState {
     title: string,
     description?: string,
     color?: string,
+    notificationPreference?: "enabled" | "disabled",
   ) => Promise<ICalendarList>;
   updateCalendar: (calendar: ICalendarList) => Promise<void>;
   deleteCalendar: (calendarId: string) => Promise<void>;
@@ -105,10 +115,12 @@ export const useCalendarLists = create<CalendarListsState>((set, get) => ({
     );
 
     // Restore visibility state from separate storage
-    const calendarsWithVisibility = cached.map((cal) => ({
-      ...cal,
-      isVisible: visibility[cal.id] !== undefined ? visibility[cal.id] : true,
-    }));
+    const calendarsWithVisibility = cached.map((cal) =>
+      withNotificationPreference({
+        ...cal,
+        isVisible: visibility[cal.id] !== undefined ? visibility[cal.id] : true,
+      }),
+    );
 
     if (calendarsWithVisibility.length > 0) {
       set({ calendars: calendarsWithVisibility, isLoaded: true });
@@ -144,6 +156,8 @@ export const useCalendarLists = create<CalendarListsState>((set, get) => ({
         // Preserve client-side visibility state
         list.isVisible =
           visibility[list.id] !== undefined ? visibility[list.id] : true;
+        list.notificationPreference =
+          list.notificationPreference ?? DEFAULT_NOTIFICATION_PREFERENCE;
         fetchedCalendars.push(list);
 
         // Merge with existing: replace if newer, add if new
@@ -193,11 +207,17 @@ export const useCalendarLists = create<CalendarListsState>((set, get) => ({
   /**
    * Creates a new calendar with the given properties and publishes it.
    */
-  createCalendar: async (title, description = "", color = "#4285f4") => {
+  createCalendar: async (
+    title,
+    description = "",
+    color = "#4285f4",
+    notificationPreference = DEFAULT_NOTIFICATION_PREFERENCE,
+  ) => {
     const newCalendar = await createCalendar({
       title,
       description,
       color,
+      notificationPreference,
       eventId: "",
       eventRefs: [],
       isVisible: true,
@@ -218,6 +238,8 @@ export const useCalendarLists = create<CalendarListsState>((set, get) => ({
   updateCalendar: async (calendar) => {
     const updated = {
       ...calendar,
+      notificationPreference:
+        calendar.notificationPreference ?? DEFAULT_NOTIFICATION_PREFERENCE,
       createdAt: Math.floor(Date.now() / 1000),
     };
     const publishedEvent = await publishCalendarList(updated);

--- a/src/stores/events.test.ts
+++ b/src/stores/events.test.ts
@@ -69,6 +69,7 @@ vi.mock("../utils/parser", () => ({
 // Mock notifications
 vi.mock("../utils/notifications", () => ({
   scheduleEventNotifications: vi.fn(),
+  cancelEventNotifications: vi.fn(),
 }));
 
 describe("parseEventRef", () => {

--- a/src/stores/events.ts
+++ b/src/stores/events.ts
@@ -45,11 +45,56 @@ import { useCalendarLists } from "./calendarLists";
 import { parseEventRef } from "../utils/calendarListTypes";
 import type { SubscriptionHandle } from "../common/nostrRuntime";
 import { getDTag } from "../common/nostrRuntime/utils/helpers";
+import { shouldScheduleNotifications } from "../utils/notificationPreferences";
 
 export const EVENTS_STORAGE_KEY = "cal:events";
 
 const saveEventsToStorage = (events: ICalendarEvent[]) => {
   setSecureItem(EVENTS_STORAGE_KEY, events);
+};
+
+const getCalendarNotificationPreference = (
+  calendarId?: string,
+): "enabled" | "disabled" | undefined => {
+  if (!calendarId) return undefined;
+  const calendar = useCalendarLists
+    .getState()
+    .calendars.find((c) => c.id === calendarId);
+  return calendar?.notificationPreference;
+};
+
+const syncEventNotifications = (
+  event: ICalendarEvent,
+  { cancelExisting = false }: { cancelExisting?: boolean } = {},
+) => {
+  const calendarPreference = getCalendarNotificationPreference(event.calendarId);
+  const shouldSchedule = shouldScheduleNotifications(
+    event.notificationPreference,
+    calendarPreference,
+  );
+
+  const schedule = () => {
+    scheduleEventNotifications(event).then((notifications) => {
+      useNotifications.getState().setNotifications(event.id, notifications);
+    });
+  };
+
+  if (!shouldSchedule) {
+    cancelEventNotifications(event.id).then(() => {
+      useNotifications.getState().removeNotifications(event.id);
+    });
+    return;
+  }
+
+  if (cancelExisting) {
+    cancelEventNotifications(event.id).then(() => {
+      useNotifications.getState().removeNotifications(event.id);
+      schedule();
+    });
+    return;
+  }
+
+  schedule();
 };
 
 let publicSubscription: SubscriptionHandle | undefined;
@@ -134,9 +179,7 @@ const processPrivateEvent = (
     }
   }
   console.log(parsedEvent);
-  scheduleEventNotifications(parsedEvent).then((notifications) => {
-    useNotifications.getState().setNotifications(parsedEvent.id, notifications);
-  });
+  syncEventNotifications(parsedEvent);
   const updatedEvents = denormalize(store);
   saveEventsToStorage(updatedEvents);
   useTimeBasedEvents.setState({
@@ -172,6 +215,7 @@ export const useTimeBasedEvents = create<{
     daysBefore?: number;
     daysAfter?: number;
   }) => void;
+  refreshNotificationPreferencesForCalendar: (calendarId: string) => void;
 }>((set) => ({
   updateEvent: (updatedEvent) => {
     set(({ events }) => {
@@ -187,15 +231,7 @@ export const useTimeBasedEvents = create<{
         events: updatedEvents,
       };
     });
-    // Cancel old notifications and reschedule with updated event data
-    cancelEventNotifications(updatedEvent.id).then(() => {
-      useNotifications.getState().removeNotifications(updatedEvent.id);
-      scheduleEventNotifications(updatedEvent).then((notifications) => {
-        useNotifications
-          .getState()
-          .setNotifications(updatedEvent.id, notifications);
-      });
-    });
+    syncEventNotifications(updatedEvent, { cancelExisting: true });
   },
   removeEvent: (id) => {
     set(({ events }) => {
@@ -247,6 +283,14 @@ export const useTimeBasedEvents = create<{
   getTimeRangeConfig,
   updateTimeRangeConfig: (newConfig) => {
     Object.assign(getTimeRangeConfig(), newConfig);
+  },
+  refreshNotificationPreferencesForCalendar: (calendarId) => {
+    const { events } = useTimeBasedEvents.getState();
+    events
+      .filter((event) => event.calendarId === calendarId)
+      .forEach((event) => {
+        syncEventNotifications(event, { cancelExisting: true });
+      });
   },
 
   /**
@@ -384,7 +428,7 @@ export const useTimeBasedEvents = create<{
           } else {
             store = appendOne(store, parsedEvent.id, parsedEvent);
           }
-          scheduleEventNotifications(parsedEvent);
+          syncEventNotifications(parsedEvent);
           const updatedEvents = denormalize(store);
           saveEventsToStorage(updatedEvents);
           return {

--- a/src/stores/events.ts
+++ b/src/stores/events.ts
@@ -63,38 +63,33 @@ const getCalendarNotificationPreference = (
   return calendar?.notificationPreference;
 };
 
-const syncEventNotifications = (
+const syncEventNotifications = async (
   event: ICalendarEvent,
   { cancelExisting = false }: { cancelExisting?: boolean } = {},
-) => {
+): Promise<void> => {
   const calendarPreference = getCalendarNotificationPreference(event.calendarId);
   const shouldSchedule = shouldScheduleNotifications(
     event.notificationPreference,
     calendarPreference,
   );
 
-  const schedule = () => {
-    scheduleEventNotifications(event).then((notifications) => {
-      useNotifications.getState().setNotifications(event.id, notifications);
-    });
-  };
-
-  if (!shouldSchedule) {
-    cancelEventNotifications(event.id).then(() => {
+  try {
+    if (!shouldSchedule) {
+      await cancelEventNotifications(event.id);
       useNotifications.getState().removeNotifications(event.id);
-    });
-    return;
-  }
+      return;
+    }
 
-  if (cancelExisting) {
-    cancelEventNotifications(event.id).then(() => {
+    if (cancelExisting) {
+      await cancelEventNotifications(event.id);
       useNotifications.getState().removeNotifications(event.id);
-      schedule();
-    });
-    return;
-  }
+    }
 
-  schedule();
+    const notifications = await scheduleEventNotifications(event);
+    useNotifications.getState().setNotifications(event.id, notifications);
+  } catch (error) {
+    console.warn("Failed to sync event notifications", error);
+  }
 };
 
 let publicSubscription: SubscriptionHandle | undefined;
@@ -179,7 +174,7 @@ const processPrivateEvent = (
     }
   }
   console.log(parsedEvent);
-  syncEventNotifications(parsedEvent);
+  void syncEventNotifications(parsedEvent);
   const updatedEvents = denormalize(store);
   saveEventsToStorage(updatedEvents);
   useTimeBasedEvents.setState({
@@ -231,7 +226,7 @@ export const useTimeBasedEvents = create<{
         events: updatedEvents,
       };
     });
-    syncEventNotifications(updatedEvent, { cancelExisting: true });
+    void syncEventNotifications(updatedEvent, { cancelExisting: true });
   },
   removeEvent: (id) => {
     set(({ events }) => {
@@ -286,11 +281,19 @@ export const useTimeBasedEvents = create<{
   },
   refreshNotificationPreferencesForCalendar: (calendarId) => {
     const { events } = useTimeBasedEvents.getState();
-    events
-      .filter((event) => event.calendarId === calendarId)
-      .forEach((event) => {
-        syncEventNotifications(event, { cancelExisting: true });
-      });
+    const relevantEvents = events.filter((event) => event.calendarId === calendarId);
+
+    void (async () => {
+      const batchSize = 5;
+      for (let i = 0; i < relevantEvents.length; i += batchSize) {
+        const batch = relevantEvents.slice(i, i + batchSize);
+        await Promise.allSettled(
+          batch.map((event) =>
+            syncEventNotifications(event, { cancelExisting: true }),
+          ),
+        );
+      }
+    })();
   },
 
   /**
@@ -428,7 +431,7 @@ export const useTimeBasedEvents = create<{
           } else {
             store = appendOne(store, parsedEvent.id, parsedEvent);
           }
-          syncEventNotifications(parsedEvent);
+          void syncEventNotifications(parsedEvent);
           const updatedEvents = denormalize(store);
           saveEventsToStorage(updatedEvents);
           return {

--- a/src/utils/calendarListTypes.ts
+++ b/src/utils/calendarListTypes.ts
@@ -1,5 +1,9 @@
 import { EventKinds } from "../common/EventConfigs";
 import type { ICalendarEvent } from "./types";
+import type { NotificationPreference } from "./types";
+
+export const DEFAULT_NOTIFICATION_PREFERENCE: NotificationPreference =
+  "enabled";
 
 /**
  * Represents a private calendar list (kind 32123).
@@ -20,6 +24,11 @@ export interface ICalendarList {
   description: string;
   /** Hex color string for theming event cards, e.g. "#4285f4" */
   color: string;
+  /**
+   * Calendar-level notification preference.
+   * Used when an event does not define its own preference.
+   */
+  notificationPreference?: NotificationPreference;
   /**
    * References to calendar events as standard NIP a-tag arrays:
    * ["{kind}:{authorPubkey}:{eventDTag}", "{relayUrl}", "{viewKey}:{beginTimeSecs}::{endTimeSecs}:{isRecurring}"]

--- a/src/utils/notificationPreferences.test.ts
+++ b/src/utils/notificationPreferences.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveNotificationPreference,
+  shouldScheduleNotifications,
+} from "./notificationPreferences";
+
+describe("notification preference resolution", () => {
+  it("uses event preference when set", () => {
+    expect(resolveNotificationPreference("disabled", "enabled")).toBe(
+      "disabled",
+    );
+    expect(shouldScheduleNotifications("disabled", "enabled")).toBe(false);
+  });
+
+  it("falls back to list preference when event preference is undefined", () => {
+    expect(resolveNotificationPreference(undefined, "disabled")).toBe(
+      "disabled",
+    );
+    expect(shouldScheduleNotifications(undefined, "disabled")).toBe(false);
+  });
+
+  it("defaults to enabled when neither preference is set", () => {
+    expect(resolveNotificationPreference(undefined, undefined)).toBe("enabled");
+    expect(shouldScheduleNotifications(undefined, undefined)).toBe(true);
+  });
+});

--- a/src/utils/notificationPreferences.ts
+++ b/src/utils/notificationPreferences.ts
@@ -1,0 +1,29 @@
+import type { NotificationPreference } from "./types";
+import { DEFAULT_NOTIFICATION_PREFERENCE } from "./calendarListTypes";
+
+export function normalizeNotificationPreference(
+  value: unknown,
+): NotificationPreference | undefined {
+  if (value === "enabled" || value === "disabled") {
+    return value;
+  }
+  return undefined;
+}
+
+export function resolveNotificationPreference(
+  eventPreference?: NotificationPreference,
+  listPreference?: NotificationPreference,
+): NotificationPreference {
+  return (
+    normalizeNotificationPreference(eventPreference) ??
+    normalizeNotificationPreference(listPreference) ??
+    DEFAULT_NOTIFICATION_PREFERENCE
+  );
+}
+
+export function shouldScheduleNotifications(
+  eventPreference?: NotificationPreference,
+  listPreference?: NotificationPreference,
+): boolean {
+  return resolveNotificationPreference(eventPreference, listPreference) === "enabled";
+}

--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -67,6 +67,11 @@ export const nostrEventToCalendar = (
       case "g":
         parsedEvent.geoHash.push(value);
         break;
+      case "notification":
+        if (value === "enabled" || value === "disabled") {
+          parsedEvent.notificationPreference = value;
+        }
+        break;
       case "L":
         switch (value) {
           case "rrule":

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -33,6 +33,8 @@ export interface IScheduledNotification {
   scheduledAt: number;
 }
 
+export type NotificationPreference = "enabled" | "disabled";
+
 export interface ICalendarEvent {
   begin: number;
   description: string;
@@ -56,6 +58,11 @@ export interface ICalendarEvent {
   repeat: {
     rrule: string | null;
   };
+  /**
+   * Event-level notification preference.
+   * If undefined, calendar-list preference should be used as fallback.
+   */
+  notificationPreference?: NotificationPreference;
   calendarId?: string;
   isInvitation?: boolean;
 }


### PR DESCRIPTION
## Description

Implements issue #49 by introducing notification preferences at the calendar-list level, while preserving existing behavior and keeping event-level settings authoritative when present. Users can configure notifications per calendar list (event preference still takes priority)


## What Changed

- Added `notificationPreference` to calendar lists:
  - values: `enabled | disabled`
  - default/fallback: `enabled` (non-breaking for existing users/data)
- Added optional event-level `notificationPreference` parsing/publishing support.
- Added shared resolution logic:
  - `event notificationPreference` (if set) takes priority
  - else use `calendar.notificationPreference`
  - else default to `enabled`
- Updated event scheduling flow to respect effective preference.
- Added UI in calendar create/edit dialog to set list notification preference.
- When a calendar preference changes, notifications for events in that calendar are re-synced.
- Added/updated tests for:
  - preference resolution behavior
  - calendar list encrypt/decrypt roundtrip including notification preference
  - calendar list store compatibility/default behavior

<img width="886" height="638" alt="Screenshot 2026-04-11 000325" src="https://github.com/user-attachments/assets/5c54df23-f2d0-4768-8985-2a3396e4aebe" />

## Issue

Closes #49
