### PR TITLE
Adds a dynamic favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/logo.png" />
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1.0, viewport-fit=cover"

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,9 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App";
 import "./main.css";
+import { initCalendarFavicon } from './utils/calendarFavicon';
+
+initCalendarFavicon();
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/src/utils/calendarFavicon.ts
+++ b/src/utils/calendarFavicon.ts
@@ -1,18 +1,21 @@
 export function initCalendarFavicon(): void {
-  const day = new Date().getDate();
+  const now = new Date();
+  const day = now.getDate();
+  const month = now.toLocaleString('default', { month: 'short' }).toUpperCase();
+
   const canvas = document.createElement('canvas');
   canvas.width = 32;
   canvas.height = 32;
   const ctx = canvas.getContext('2d');
   if (!ctx) return;
 
-  // Rounded white background
+  // Black rounded background
   ctx.beginPath();
   ctx.roundRect(0, 0, 32, 32, 7);
-  ctx.fillStyle = '#ffffff';
+  ctx.fillStyle = '#111111';
   ctx.fill();
 
-  // Red header strip (clipped)
+  // Red header strip (clipped to rounded corners)
   ctx.save();
   ctx.beginPath();
   ctx.roundRect(0, 0, 32, 32, 7);
@@ -21,16 +24,23 @@ export function initCalendarFavicon(): void {
   ctx.fillRect(0, 0, 32, 10);
   ctx.restore();
 
+  // Month label inside red strip
+  ctx.fillStyle = 'rgba(255,255,255,0.85)';
+  ctx.font = 'bold 5px system-ui,sans-serif';
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(month, 16, 5);
+
   // Date number
-  ctx.fillStyle = '#1a1a1a';
-  ctx.font = 'bold 17px system-ui, sans-serif';
+  ctx.fillStyle = '#ffffff';
+  ctx.font = 'bold 14px system-ui,sans-serif';
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
   ctx.fillText(String(day), 16, 22);
 
   // Inject favicon
   const link =
-    (document.querySelector("link[rel~='icon']") as HTMLLinkElement) ||
+    (document.querySelector("link[rel~='icon']") as HTMLLinkElement) ??
     document.createElement('link');
   link.rel = 'icon';
   link.type = 'image/png';
@@ -38,7 +48,6 @@ export function initCalendarFavicon(): void {
   document.head.appendChild(link);
 
   // Schedule refresh at midnight
-  const now = new Date();
   const msToMidnight =
     new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1).getTime() - now.getTime();
   setTimeout(initCalendarFavicon, msToMidnight);

--- a/src/utils/calendarFavicon.ts
+++ b/src/utils/calendarFavicon.ts
@@ -1,0 +1,45 @@
+export function initCalendarFavicon(): void {
+  const day = new Date().getDate();
+  const canvas = document.createElement('canvas');
+  canvas.width = 32;
+  canvas.height = 32;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return;
+
+  // Rounded white background
+  ctx.beginPath();
+  ctx.roundRect(0, 0, 32, 32, 7);
+  ctx.fillStyle = '#ffffff';
+  ctx.fill();
+
+  // Red header strip (clipped)
+  ctx.save();
+  ctx.beginPath();
+  ctx.roundRect(0, 0, 32, 32, 7);
+  ctx.clip();
+  ctx.fillStyle = '#E24B4A';
+  ctx.fillRect(0, 0, 32, 10);
+  ctx.restore();
+
+  // Date number
+  ctx.fillStyle = '#1a1a1a';
+  ctx.font = 'bold 17px system-ui, sans-serif';
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(String(day), 16, 22);
+
+  // Inject favicon
+  const link =
+    (document.querySelector("link[rel~='icon']") as HTMLLinkElement) ||
+    document.createElement('link');
+  link.rel = 'icon';
+  link.type = 'image/png';
+  link.href = canvas.toDataURL('image/png');
+  document.head.appendChild(link);
+
+  // Schedule refresh at midnight
+  const now = new Date();
+  const msToMidnight =
+    new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1).getTime() - now.getTime();
+  setTimeout(initCalendarFavicon, msToMidnight);
+}


### PR DESCRIPTION
Closes #92 

Adds a dynamic favicon that displays today's date as a mini calendar icon, replacing the static `logo.png`.

The favicon auto-refreshes at midnight using a `setTimeout` scheduled to the exact ms until the next day. Users who leave the tab open overnight will see the date flip automatically — no page reload needed.

<img width="375" height="167" alt="Screenshot 2026-04-12 at 7 04 10 PM" src="https://github.com/user-attachments/assets/8e467dde-a01d-4cbd-bc15-d172c972d5e3" />
