### PR TITLE
fix: interpret floating RRULE dates as UTC per RFC 5545

### DIFF
--- a/src/utils/repeatingEventsHelper.test.ts
+++ b/src/utils/repeatingEventsHelper.test.ts
@@ -103,6 +103,27 @@ describe("rruleToFrequency", () => {
   });
 });
 
+describe("parseRRuleDate", () => {
+  it("parses UTC dates correctly", () => {
+    const rrule = "FREQ=DAILY;UNTIL=20250101T120000Z";
+    const parsed = parseRecurrenceRule(rrule);
+    expect(parsed.untilDate).toBe(Date.UTC(2025, 0, 1, 12, 0, 0));
+  });
+
+  it("parses floating dates (without Z) as UTC to ensure timezone independence", () => {
+    const rrule = "FREQ=DAILY;UNTIL=20250101T120000";
+    const parsed = parseRecurrenceRule(rrule);
+    // Should be UTC per RFC 5545 floating time requirement for this app's logic
+    expect(parsed.untilDate).toBe(Date.UTC(2025, 0, 1, 12, 0, 0));
+  });
+
+  it("parses date-only strings as UTC to ensure timezone independence", () => {
+    const rrule = "FREQ=DAILY;UNTIL=20250101";
+    const parsed = parseRecurrenceRule(rrule);
+    expect(parsed.untilDate).toBe(Date.UTC(2025, 0, 1, 0, 0, 0));
+  });
+});
+
 // ─── parseRecurrenceRule / buildRecurrenceRule ─────────────────────
 
 describe("parseRecurrenceRule", () => {

--- a/src/utils/repeatingEventsHelper.ts
+++ b/src/utils/repeatingEventsHelper.ts
@@ -140,22 +140,22 @@ function parseRRuleDate(value: string): number | null {
   }
 
   if (/^\d{8}T\d{6}$/.test(clean)) {
-    return new Date(
+    return Date.UTC(
       Number.parseInt(clean.slice(0, 4), 10),
       Number.parseInt(clean.slice(4, 6), 10) - 1,
       Number.parseInt(clean.slice(6, 8), 10),
       Number.parseInt(clean.slice(9, 11), 10),
       Number.parseInt(clean.slice(11, 13), 10),
       Number.parseInt(clean.slice(13, 15), 10),
-    ).getTime();
+    );
   }
 
   if (/^\d{8}$/.test(clean)) {
-    return new Date(
+    return Date.UTC(
       Number.parseInt(clean.slice(0, 4), 10),
       Number.parseInt(clean.slice(4, 6), 10) - 1,
       Number.parseInt(clean.slice(6, 8), 10),
-    ).getTime();
+    );
   }
 
   return null;


### PR DESCRIPTION
Fixes #100 