### PR TITLE
chore: bump version to 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nostr-calendar",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "type": "module",
   "repository": {
     "url": "https://github.com/formstr-hq/nostr-calendar"


### PR DESCRIPTION
Update package.json version from 1.2.1 to 1.3.0, indicating a minor release with new features or enhancements while maintaining backward compatibility.