### PR TITLE
refactor: decouple calendar event publishing from calendar list management

### DIFF
--- a/src/common/nostr.ts
+++ b/src/common/nostr.ts
@@ -170,10 +170,7 @@ async function preparePrivateCalendarEvent(
   };
 }
 
-export async function publishPrivateCalendarEvent(
-  event: ICalendarEvent,
-  calendarId: string,
-) {
+export async function publishPrivateCalendarEvent(event: ICalendarEvent) {
   const viewSecretKey = generateSecretKey();
   const dTagRoot = `${JSON.stringify(event)}-${Date.now()}`;
   const dTag = bytesToHex(sha256(utf8ToBytes(dTagRoot))).substring(0, 30);
@@ -235,9 +232,10 @@ export async function publishPrivateCalendarEvent(
     relayUrl: publishedRelayHint,
     viewKey: nip19.nsecEncode(viewSecretKey),
   });
-  await useCalendarLists.getState().addEventToCalendar(calendarId, eventRef);
 
   return {
+    eventRef,
+    authorPubkey: userPublicKey,
     calendarEvent: signedEvent,
     giftWraps: giftWraps.map(({ giftWrap }) => giftWrap),
   };

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -11,9 +11,8 @@ import { useInvitations } from "../stores/invitations";
 
 function Calendar() {
   const events = useTimeBasedEvents((state) => state);
-  const { calendars } = useCalendarLists();
+  const calendars = useCalendarLists((state) => state.calendars);
   const { invitations } = useInvitations();
-
   const { layout } = useLayout();
   const visibileCalendars = new Set(
     calendars.filter((cal) => cal.isVisible).map((cal) => cal.id),
@@ -21,6 +20,7 @@ function Calendar() {
   const visibleEvents = events.events.filter((evt) =>
     visibileCalendars.has(evt.calendarId ?? ""),
   );
+
   const allEvents = [
     ...visibleEvents,
     ...invitations.filter((inv) => inv.event).map((inv) => inv.event!),

--- a/src/components/CalendarEvent.tsx
+++ b/src/components/CalendarEvent.tsx
@@ -314,14 +314,13 @@ function ActionButtons({
       minWidth={isMobile ? "inherit" : "160px"}
       sx={{ whiteSpace: "nowrap" }}
     >
+      <IconButton size={iconSize} onClick={copyLinkToEvent}>
+        <Tooltip title={intl.formatMessage({ id: "event.copyLink" })}>
+          <ContentCopy fontSize={iconSize} />
+        </Tooltip>
+      </IconButton>
       {!isMobile && (
         <>
-          <IconButton size={iconSize} onClick={copyLinkToEvent}>
-            <Tooltip title={intl.formatMessage({ id: "event.copyLink" })}>
-              <ContentCopy fontSize={iconSize} />
-            </Tooltip>
-          </IconButton>
-
           {showOpenInNew && (
             <IconButton size={iconSize} component={Link} href={linkToEvent}>
               <Tooltip title={intl.formatMessage({ id: "event.openNewTab" })}>
@@ -550,7 +549,12 @@ function InvitationAcceptBar({ event }: { event: ICalendarEvent }) {
   const intl = useIntl();
   const navigate = useNavigate();
   const { user, updateLoginModal } = useUser();
-  const { calendars, addEventToCalendar, isLoaded: calendarsLoaded, fetchCalendars } = useCalendarLists();
+  const {
+    calendars,
+    addEventToCalendar,
+    isLoaded: calendarsLoaded,
+    fetchCalendars,
+  } = useCalendarLists();
   const { invitations, acceptInvitation } = useInvitations();
   const { updateEvent } = useTimeBasedEvents();
   const [selectedCalendarId, setSelectedCalendarId] = useState(
@@ -587,7 +591,10 @@ function InvitationAcceptBar({ event }: { event: ICalendarEvent }) {
         (inv) => inv.eventId === event.id && inv.pubkey === event.user,
       );
       if (matchingInvitation) {
-        await acceptInvitation(matchingInvitation.giftWrapId, selectedCalendarId);
+        await acceptInvitation(
+          matchingInvitation.giftWrapId,
+          selectedCalendarId,
+        );
       } else {
         const eventRef = buildEventRef({
           kind: event.kind,
@@ -596,7 +603,11 @@ function InvitationAcceptBar({ event }: { event: ICalendarEvent }) {
           viewKey: event.viewKey || "",
         });
         await addEventToCalendar(selectedCalendarId, eventRef);
-        updateEvent({ ...event, calendarId: selectedCalendarId, isInvitation: false });
+        updateEvent({
+          ...event,
+          calendarId: selectedCalendarId,
+          isInvitation: false,
+        });
       }
       setSuccessDialogOpen(true);
     } catch {
@@ -609,7 +620,10 @@ function InvitationAcceptBar({ event }: { event: ICalendarEvent }) {
   const handleContinueAsGuest = async () => {
     setCreatingGuest(true);
     try {
-      await signerManager.createGuestAccount(bytesToHex(generateSecretKey()), {});
+      await signerManager.createGuestAccount(
+        bytesToHex(generateSecretKey()),
+        {},
+      );
     } catch {
       setErrorOpen(true);
     } finally {
@@ -648,7 +662,9 @@ function InvitationAcceptBar({ event }: { event: ICalendarEvent }) {
               disabled={creatingGuest}
               onClick={handleContinueAsGuest}
               startIcon={
-                creatingGuest ? <CircularProgress size={14} color="inherit" /> : undefined
+                creatingGuest ? (
+                  <CircularProgress size={14} color="inherit" />
+                ) : undefined
               }
             >
               {intl.formatMessage({ id: "message.modeSelection_guestButton" })}
@@ -707,9 +723,15 @@ function InvitationAcceptBar({ event }: { event: ICalendarEvent }) {
             component="span"
           >
             <FormattedMessage
-              id={event.isInvitation ? "invitation.invitedBy" : "invitation.createdBy"}
+              id={
+                event.isInvitation
+                  ? "invitation.invitedBy"
+                  : "invitation.createdBy"
+              }
               values={{
-                participant: <Participant pubKey={event.user} isAuthor={false} />,
+                participant: (
+                  <Participant pubKey={event.user} isAuthor={false} />
+                ),
               }}
             />
           </Typography>
@@ -732,7 +754,9 @@ function InvitationAcceptBar({ event }: { event: ICalendarEvent }) {
             onClick={handleAccept}
             sx={{ flexShrink: 0, whiteSpace: "nowrap" }}
             startIcon={
-              accepting ? <CircularProgress size={14} color="inherit" /> : undefined
+              accepting ? (
+                <CircularProgress size={14} color="inherit" />
+              ) : undefined
             }
           >
             {intl.formatMessage({ id: "invitation.acceptInvitation" })}

--- a/src/components/CalendarEventEdit.tsx
+++ b/src/components/CalendarEventEdit.tsx
@@ -51,6 +51,7 @@ import { getRelays } from "../common/nostr";
 import { useRelayStore } from "../stores/relays";
 import { useCalendarLists } from "../stores/calendarLists";
 import { useTimeBasedEvents } from "../stores/events";
+import { parseEventRef } from "../utils/calendarListTypes";
 import { CalendarListSelect } from "./CalendarListSelect";
 
 interface CalendarEventEditProps {
@@ -279,7 +280,7 @@ export function CalendarEventEdit({
   const [isPrivate, setIsPrivate] = useState(
     initialEvent?.isPrivateEvent ?? true,
   );
-  const { calendars } = useCalendarLists();
+  const { calendars, addEventToCalendar } = useCalendarLists();
   const [selectedCalendarId, setSelectedCalendarId] = useState<string>(
     initialEvent?.calendarId || calendars[0]?.id || "",
   );
@@ -411,7 +412,17 @@ export function CalendarEventEdit({
             .getState()
             .updateEvent({ ...updates.event, calendarId: updates.calendarId });
         } else {
-          await publishPrivateCalendarEvent(eventToSave, selectedCalendarId);
+          const { eventRef, authorPubkey } =
+            await publishPrivateCalendarEvent(eventToSave);
+          await addEventToCalendar(selectedCalendarId, eventRef);
+          const { eventDTag, viewKey } = parseEventRef(eventRef);
+          useTimeBasedEvents.getState().addEvent({
+            ...eventToSave,
+            id: eventDTag,
+            viewKey,
+            user: authorPubkey,
+            calendarId: selectedCalendarId,
+          });
         }
       } else {
         const { id: savedId, pubKey } =

--- a/src/stores/events.ts
+++ b/src/stores/events.ts
@@ -205,6 +205,7 @@ export const useTimeBasedEvents = create<{
     daysBefore?: number;
     daysAfter?: number;
   }) => void;
+  addEvent: (event: ICalendarEvent) => void;
   updateEvent: (event: ICalendarEvent) => void;
   removeEvent: (id: string) => void;
   resetPrivateEvents: () => void;
@@ -215,6 +216,18 @@ export const useTimeBasedEvents = create<{
   }) => void;
   refreshNotificationPreferencesForCalendar: (calendarId: string) => void;
 }>((set) => ({
+  addEvent: (newEvent) => {
+    set(({ events }) => {
+      const store = normalize(events);
+      if (store.allKeys.includes(newEvent.id))
+        return { events, eventById: store.byKey };
+      const updated = appendOne(store, newEvent.id, newEvent);
+      const updatedEvents = denormalize(updated);
+      saveEventsToStorage(updatedEvents);
+      return { eventById: updated.byKey, events: updatedEvents };
+    });
+    void syncEventNotifications(newEvent);
+  },
   updateEvent: (updatedEvent) => {
     set(({ events }) => {
       let store = normalize(events);


### PR DESCRIPTION
Refactored `publishPrivateCalendarEvent` to remove calendar list dependency and improve separation of concerns:

- Remove `calendarId` parameter from `publishPrivateCalendarEvent`
- Return `eventRef` and `authorPubkey` instead of auto-adding to calendar
- Allow callers to handle calendar list updates explicitly
- Improve code organization in Calendar component with direct state selector
- Make copy link button accessible on mobile devices
- Apply consistent code formatting across components

This change separates publishing logic from calendar management, giving callers more control over when and how events are added to calendar lists.