### PR TITLE
Add relay publish progress feedback for event saves

### DIFF
--- a/src/common/dictionary.ts
+++ b/src/common/dictionary.ts
@@ -94,6 +94,11 @@ const dictionary: NestedObject = {
       private: "Private",
       public: "Public",
       publishingToRelays: "Publishing to {count} relay(s)",
+      publishingEvent: "Publishing Event",
+      relaysPublishStatus: "Relays{complete}",
+      eventSaved: "Your event has been saved",
+      noRelaysAccepted:
+        "No relays accepted the event. Please check your relay configuration and try again.",
       saving: "Saving...",
       saveEvent: "Save Event",
       copyLink: "Copy link to this event",
@@ -303,6 +308,11 @@ const dictionary: NestedObject = {
       private: "Privat",
       public: "Öffentlich",
       publishingToRelays: "Veröffentlichung an {count} Relay(s)",
+      publishingEvent: "Termin veröffentlichen",
+      relaysPublishStatus: "Relays{complete}",
+      eventSaved: "Ihr Termin wurde gespeichert",
+      noRelaysAccepted:
+        "Kein Relay hat den Termin akzeptiert. Bitte überprüfen Sie Ihre Relay-Konfiguration und versuchen Sie es erneut.",
       saving: "Speichern...",
       saveEvent: "Termin speichern",
       copyLink: "Link zu diesem Termin kopieren",

--- a/src/common/dictionary.ts
+++ b/src/common/dictionary.ts
@@ -99,6 +99,14 @@ const dictionary: NestedObject = {
       eventSaved: "Your event has been saved",
       noRelaysAccepted:
         "No relays accepted the event. Please check your relay configuration and try again.",
+      relayDetails: "Details",
+      relayPartialFailure:
+        "Some relays did not accept the event. You can try again for failed relays only.",
+      retryFailedRelays: "Retry failed relays",
+      closeEditor: "Close",
+      note: "Note",
+      partialPublishHint:
+        "The event is on your calendar. Retry to publish to relays that did not accept.",
       saving: "Saving...",
       saveEvent: "Save Event",
       copyLink: "Copy link to this event",
@@ -313,6 +321,14 @@ const dictionary: NestedObject = {
       eventSaved: "Ihr Termin wurde gespeichert",
       noRelaysAccepted:
         "Kein Relay hat den Termin akzeptiert. Bitte überprüfen Sie Ihre Relay-Konfiguration und versuchen Sie es erneut.",
+      relayDetails: "Details",
+      relayPartialFailure:
+        "Einige Relays haben den Termin nicht akzeptiert. Sie können nur fehlgeschlagene Relays erneut versuchen.",
+      retryFailedRelays: "Fehlgeschlagene Relays erneut senden",
+      closeEditor: "Schließen",
+      note: "Hinweis",
+      partialPublishHint:
+        "Der Termin ist in Ihrem Kalender. Wiederholen, um an Relays zu senden, die nicht angenommen haben.",
       saving: "Speichern...",
       saveEvent: "Termin speichern",
       copyLink: "Link zu diesem Termin kopieren",

--- a/src/common/nostr.ts
+++ b/src/common/nostr.ts
@@ -69,31 +69,26 @@ export const ensureRelay = async (
   return relay;
 };
 
-export async function publishPrivateRSVPEvent({
-  authorpubKey, // Public key of the event author
-  eventId, // The dtag of the event
-  status, // Status of the RSVP event
-  participants, // List of participant public keys
-  referenceKind,
-}: {
+export async function publishPrivateRSVPEvent(params: {
   eventId: string;
+  // Public key of the event author
   authorpubKey: string;
+  // RSVP status for the event
   status: string;
+  // List of participant public keys
   participants: string[];
   referenceKind: EventKinds.PrivateCalendarEvent;
 }) {
+  void params;
   // this function is noop
 }
 
-export async function publishPublicRSVPEvent({
-  authorpubKey,
-  eventId,
-  status,
-}: {
+export async function publishPublicRSVPEvent(params: {
   authorpubKey: string;
   eventId: string;
   status: string;
 }) {
+  void params;
   // this function is noop
 }
 
@@ -173,6 +168,7 @@ async function preparePrivateCalendarEvent(
 export async function publishPrivateCalendarEvent(
   event: ICalendarEvent,
   calendarId: string,
+  onAcceptedRelays?: (url: string) => void,
 ) {
   const viewSecretKey = generateSecretKey();
   const dTagRoot = `${JSON.stringify(event)}-${Date.now()}`;
@@ -183,9 +179,15 @@ export async function publishPrivateCalendarEvent(
   // Capture which relay accepts the event to use as a hint in invitations
   // and the creator's calendar list entry, so recipients can fetch from there.
   let publishedRelayHint = "";
-  await publishToRelays(signedEvent, (url) => {
-    if (!publishedRelayHint) publishedRelayHint = url;
-  });
+  await publishToRelays(
+    signedEvent,
+    (url) => {
+      if (!publishedRelayHint) publishedRelayHint = url;
+      onAcceptedRelays?.(url);
+    },
+    undefined,
+    { waitForAll: true },
+  );
 
   // Gift-wrap the event keys to each participant (including the creator).
   // These serve as invitations — recipients will see them as notifications
@@ -246,13 +248,16 @@ export async function publishPrivateCalendarEvent(
 export async function editPrivateCalendarEvent(
   event: ICalendarEvent,
   calendarId: string,
+  onAcceptedRelays?: (url: string) => void,
 ) {
   const dTag = event.id;
   const viewSecretKey = nip19.decode(event.viewKey as NSec).data;
   const { signedEvent, eventKind, userPublicKey } =
     await preparePrivateCalendarEvent(event, dTag, viewSecretKey);
 
-  await publishToRelays(signedEvent);
+  await publishToRelays(signedEvent, onAcceptedRelays, undefined, {
+    waitForAll: true,
+  });
 
   const eventCoordinate = `${eventKind}:${userPublicKey}:${dTag}`;
   const eventRef = buildEventRef({
@@ -502,33 +507,53 @@ export const publishToRelays = (
   event: Event,
   onAcceptedRelays: (url: string) => void = _onAcceptedRelays,
   relays?: string[],
+  options: { waitForAll?: boolean } = {},
 ) => {
-  const relayList = (relays ?? getRelays()).map(normalizeURL);
-  return Promise.any(
-    relayList.map(async (url) => {
-      let relay: AbstractRelay | null = null;
-      try {
-        relay = await ensureRelay(url, { connectionTimeout: 5000 });
-        return await Promise.race<string>([
-          relay.publish(event).then((reason) => {
-            onAcceptedRelays(url);
-            return reason;
-          }),
-          new Promise<string>((_, reject) =>
-            setTimeout(() => reject("timeout"), 5000),
-          ),
-        ]);
-      } finally {
-        if (relay) {
-          try {
-            await relay.close();
-          } catch {
-            // Ignore closing errors
-          }
+  const relayList = Array.from(
+    new Set((relays ?? getRelays()).map(normalizeURL)),
+  );
+  const publishPromises = relayList.map(async (url) => {
+    let relay: AbstractRelay | null = null;
+    try {
+      relay = await ensureRelay(url, { connectionTimeout: 5000 });
+      return await Promise.race<string>([
+        relay.publish(event).then((reason) => {
+          onAcceptedRelays(url);
+          return reason;
+        }),
+        new Promise<string>((_, reject) =>
+          setTimeout(() => reject("timeout"), 5000),
+        ),
+      ]);
+    } finally {
+      if (relay) {
+        try {
+          await relay.close();
+        } catch {
+          // Ignore closing errors
         }
       }
-    }),
-  );
+    }
+  });
+
+  if (options.waitForAll) {
+    return Promise.allSettled(publishPromises).then((results) => {
+      if (results.some((result) => result.status === "fulfilled")) {
+        return results;
+      }
+
+      const rejectionReasons = results.flatMap((result) =>
+        result.status === "rejected" ? [result.reason] : [],
+      );
+
+      throw new AggregateError(
+        rejectionReasons,
+        "No relays accepted the event",
+      );
+    });
+  }
+
+  return Promise.any(publishPromises);
 };
 
 export const fetchCalendarEvents = (
@@ -586,7 +611,9 @@ export const publishPublicCalendarEvent = async (
   const signer = await signerManager.getSigner();
   const fullEvent = await signer.signEvent(baseEvent);
   fullEvent.id = getEventHash(baseEvent);
-  const result = await publishToRelays(fullEvent, onAcceptedRelays);
+  const result = await publishToRelays(fullEvent, onAcceptedRelays, undefined, {
+    waitForAll: true,
+  });
 
   return { result, id, pubKey };
 };

--- a/src/common/nostr.ts
+++ b/src/common/nostr.ts
@@ -168,6 +168,7 @@ async function preparePrivateCalendarEvent(
 export async function publishPrivateCalendarEvent(
   event: ICalendarEvent,
   onAcceptedRelays?: (url: string) => void,
+  onRelayComplete?: (url: string, success: boolean) => void,
 ) {
   const viewSecretKey = generateSecretKey();
   const dTagRoot = `${JSON.stringify(event)}-${Date.now()}`;
@@ -185,7 +186,7 @@ export async function publishPrivateCalendarEvent(
       onAcceptedRelays?.(url);
     },
     undefined,
-    { waitForAll: true },
+    { waitForAll: true, onRelayComplete },
   );
 
   // Gift-wrap the event keys to each participant (including the creator).
@@ -249,6 +250,7 @@ export async function editPrivateCalendarEvent(
   event: ICalendarEvent,
   calendarId: string,
   onAcceptedRelays?: (url: string) => void,
+  onRelayComplete?: (url: string, success: boolean) => void,
 ) {
   const dTag = event.id;
   const viewSecretKey = nip19.decode(event.viewKey as NSec).data;
@@ -257,6 +259,7 @@ export async function editPrivateCalendarEvent(
 
   await publishToRelays(signedEvent, onAcceptedRelays, undefined, {
     waitForAll: true,
+    onRelayComplete,
   });
 
   const eventCoordinate = `${eventKind}:${userPublicKey}:${dTag}`;
@@ -274,6 +277,7 @@ export async function editPrivateCalendarEvent(
   return {
     event,
     calendarId,
+    signedEvent,
   };
 }
 
@@ -509,8 +513,12 @@ export const publishToRelays = (
   event: Event,
   onAcceptedRelays: (url: string) => void = _onAcceptedRelays,
   relays?: string[],
-  options: { waitForAll?: boolean } = {},
+  options: {
+    waitForAll?: boolean;
+    onRelayComplete?: (url: string, success: boolean) => void;
+  } = {},
 ) => {
+  const { onRelayComplete } = options;
   const relayList = Array.from(
     new Set((relays ?? getRelays()).map(normalizeURL)),
   );
@@ -518,15 +526,20 @@ export const publishToRelays = (
     let relay: AbstractRelay | null = null;
     try {
       relay = await ensureRelay(url, { connectionTimeout: 5000 });
-      return await Promise.race<string>([
-        relay.publish(event).then((reason) => {
+      const reason = await Promise.race<string>([
+        relay.publish(event).then((r) => {
           onAcceptedRelays(url);
-          return reason;
+          return r;
         }),
         new Promise<string>((_, reject) =>
           setTimeout(() => reject("timeout"), 5000),
         ),
       ]);
+      onRelayComplete?.(url, true);
+      return reason;
+    } catch (e) {
+      onRelayComplete?.(url, false);
+      throw e;
     } finally {
       if (relay) {
         try {
@@ -558,6 +571,18 @@ export const publishToRelays = (
   return Promise.any(publishPromises);
 };
 
+/** Re-publish a signed event to a subset of relays (e.g. retry after partial failure). */
+export const republishEventToRelays = (
+  event: Event,
+  relayUrls: string[],
+  onAcceptedRelays?: (url: string) => void,
+  onRelayComplete?: (url: string, success: boolean) => void,
+) =>
+  publishToRelays(event, onAcceptedRelays ?? (() => {}), relayUrls, {
+    waitForAll: true,
+    onRelayComplete,
+  });
+
 export const fetchCalendarEvents = (
   { since, until }: { since?: number; until?: number },
   onEvent: (event: Event) => void,
@@ -579,6 +604,7 @@ export const fetchCalendarEvents = (
 export const publishPublicCalendarEvent = async (
   event: ICalendarEvent,
   onAcceptedRelays?: (url: string) => void,
+  onRelayComplete?: (url: string, success: boolean) => void,
 ) => {
   const pubKey = await getUserPublicKey();
   const id = event?.id !== TEMP_CALENDAR_ID ? event.id : uuid();
@@ -615,9 +641,10 @@ export const publishPublicCalendarEvent = async (
   fullEvent.id = getEventHash(baseEvent);
   const result = await publishToRelays(fullEvent, onAcceptedRelays, undefined, {
     waitForAll: true,
+    onRelayComplete,
   });
 
-  return { result, id, pubKey };
+  return { result, id, pubKey, signedEvent: fullEvent };
 };
 
 /**

--- a/src/components/CalendarEventEdit.tsx
+++ b/src/components/CalendarEventEdit.tsx
@@ -52,6 +52,8 @@ import { useRelayStore } from "../stores/relays";
 import { useCalendarLists } from "../stores/calendarLists";
 import { useTimeBasedEvents } from "../stores/events";
 import { CalendarListSelect } from "./CalendarListSelect";
+import { RelayPublishDialog } from "./RelayPublishDialog";
+import { normalizeURL } from "nostr-tools/utils";
 
 interface CalendarEventEditProps {
   open: boolean;
@@ -276,6 +278,10 @@ export function CalendarEventEdit({
   const initialRecurrence = parseRecurrenceRule(initialRule);
   const initialIsCustom = !!initialRule && initialRecurrence.frequency === null;
   const [processing, setProcessing] = useState(false);
+  const [relayPublishOpen, setRelayPublishOpen] = useState(false);
+  const [publishingRelays, setPublishingRelays] = useState<string[]>([]);
+  const [acceptedRelays, setAcceptedRelays] = useState<string[]>([]);
+  const [publishFailed, setPublishFailed] = useState(false);
   const [isPrivate, setIsPrivate] = useState(
     initialEvent?.isPrivateEvent ?? true,
   );
@@ -382,8 +388,24 @@ export function CalendarEventEdit({
     setCustomDialogOpen(false);
   };
 
+  const handleAcceptedRelay = (url: string) => {
+    setAcceptedRelays((prev) => (prev.includes(url) ? prev : [...prev, url]));
+  };
+
   const handleSave = async () => {
+    const relaysToPublish = Array.from(new Set(getRelays().map(normalizeURL)));
+    const acceptedRelayUrls = new Set<string>();
+    const trackAcceptedRelay = (url: string) => {
+      const normalizedUrl = normalizeURL(url);
+      acceptedRelayUrls.add(normalizedUrl);
+      handleAcceptedRelay(normalizedUrl);
+    };
+
     setProcessing(true);
+    setPublishingRelays(relaysToPublish);
+    setAcceptedRelays([]);
+    setPublishFailed(false);
+    setRelayPublishOpen(true);
     try {
       const rrule = isCustomRecurrence
         ? customRule
@@ -405,17 +427,24 @@ export function CalendarEventEdit({
           const updates = await editPrivateCalendarEvent(
             eventToSave,
             selectedCalendarId,
+            trackAcceptedRelay,
           );
 
           useTimeBasedEvents
             .getState()
             .updateEvent({ ...updates.event, calendarId: updates.calendarId });
         } else {
-          await publishPrivateCalendarEvent(eventToSave, selectedCalendarId);
+          await publishPrivateCalendarEvent(
+            eventToSave,
+            selectedCalendarId,
+            trackAcceptedRelay,
+          );
         }
       } else {
-        const { id: savedId, pubKey } =
-          await publishPublicCalendarEvent(eventToSave);
+        const { id: savedId, pubKey } = await publishPublicCalendarEvent(
+          eventToSave,
+          trackAcceptedRelay,
+        );
         useTimeBasedEvents.getState().updateEvent({
           ...eventToSave,
           id: savedId,
@@ -430,10 +459,20 @@ export function CalendarEventEdit({
       }
 
       setProcessing(false);
-      onClose();
+      if (acceptedRelayUrls.size < relaysToPublish.length) {
+        setPublishFailed(true);
+      }
     } catch (e) {
       console.error(e instanceof Error ? e.message : "Unknown error");
+      setPublishFailed(true);
       setProcessing(false);
+    }
+  };
+
+  const handlePublishDialogClose = () => {
+    setRelayPublishOpen(false);
+    if (!publishFailed) {
+      onClose();
     }
   };
 
@@ -1140,42 +1179,60 @@ export function CalendarEventEdit({
 
   if (display === "page") {
     return (
-      <Box
-        style={{
-          maxWidth: 900,
-          margin: "0 auto",
-          padding: 24,
-        }}
-      >
-        <Box style={{ marginBottom: 24 }}>{titleBar}</Box>
-        <Box style={{ marginBottom: 24 }}>{formContent}</Box>
+      <>
         <Box
           style={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "flex-end",
-            gap: 8,
-            padding: "16px 0",
+            maxWidth: 900,
+            margin: "0 auto",
+            padding: 24,
           }}
         >
-          {actions}
+          <Box style={{ marginBottom: 24 }}>{titleBar}</Box>
+          <Box style={{ marginBottom: 24 }}>{formContent}</Box>
+          <Box
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "flex-end",
+              gap: 8,
+              padding: "16px 0",
+            }}
+          >
+            {actions}
+          </Box>
         </Box>
-      </Box>
+        <RelayPublishDialog
+          open={relayPublishOpen}
+          relays={publishingRelays}
+          acceptedRelays={acceptedRelays}
+          publishFailed={publishFailed}
+          onClose={handlePublishDialogClose}
+        />
+      </>
     );
   }
 
   return (
-    <Dialog
-      fullScreen={isMobile}
-      open={open}
-      onClose={handleClose}
-      maxWidth="md"
-      fullWidth
-    >
-      <DialogTitle>{titleBar}</DialogTitle>
-      <DialogContent dividers>{formContent}</DialogContent>
-      <DialogActions style={{ padding: 16 }}>{actions}</DialogActions>
-    </Dialog>
+    <>
+      <Dialog
+        fullScreen={isMobile}
+        open={open}
+        onClose={handleClose}
+        maxWidth="md"
+        fullWidth
+      >
+        <DialogTitle>{titleBar}</DialogTitle>
+        <DialogContent dividers>{formContent}</DialogContent>
+        <DialogActions style={{ padding: 16 }}>{actions}</DialogActions>
+      </Dialog>
+      <RelayPublishDialog
+        open={relayPublishOpen}
+        relays={publishingRelays}
+        acceptedRelays={acceptedRelays}
+        publishFailed={publishFailed}
+        onClose={handlePublishDialogClose}
+      />
+    </>
   );
 }
 

--- a/src/components/CalendarEventEdit.tsx
+++ b/src/components/CalendarEventEdit.tsx
@@ -1,4 +1,4 @@
-import React, { useState, type Dispatch, type SetStateAction } from "react";
+import React, { useState } from "react";
 import {
   Dialog,
   DialogTitle,
@@ -17,8 +17,6 @@ import {
   Divider,
   useMediaQuery,
   useTheme,
-  Tooltip,
-  CircularProgress,
 } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
 import { ICalendarEvent, RepeatingFrequency } from "../utils/types";
@@ -58,7 +56,8 @@ import { useTimeBasedEvents } from "../stores/events";
 import { parseEventRef } from "../utils/calendarListTypes";
 import { CalendarListSelect } from "./CalendarListSelect";
 import { RelayPublishDialog } from "./RelayPublishDialog";
-import { normalizeURL } from "nostr-tools/utils";
+import { RelayDots } from "./RelayDots";
+import { useRelayPublishStatus } from "../hooks/useRelayPublishStatus";
 
 interface CalendarEventEditProps {
   open: boolean;
@@ -70,30 +69,11 @@ interface CalendarEventEditProps {
   display?: "modal" | "page";
 }
 
-type RelayLineStatus = "pending" | "ok" | "error";
-
-type RelayStatusMap = Record<string, RelayLineStatus>;
-
-function createRelayCompletionHandler(
-  outcomes: Record<string, boolean>,
-  setRelayStatus: Dispatch<SetStateAction<RelayStatusMap>>,
-) {
-  return (url: string, ok: boolean) => {
-    const n = normalizeURL(url);
-    outcomes[n] = ok;
-    setRelayStatus((prev) => ({ ...prev, [n]: ok ? "ok" : "error" }));
-  };
-}
-
 const PARTIAL_PUBLISH_NOTE_SX = {
   pt: 2,
   borderTop: 1,
   borderColor: "divider" as const,
 };
-
-function normalizedRelayList(): string[] {
-  return Array.from(new Set(getRelays().map(normalizeURL)));
-}
 
 const CUSTOM_RECURRENCE_VALUE = "__custom_rule__";
 
@@ -308,8 +288,16 @@ export function CalendarEventEdit({
   const initialRecurrence = parseRecurrenceRule(initialRule);
   const initialIsCustom = !!initialRule && initialRecurrence.frequency === null;
   const [processing, setProcessing] = useState(false);
-  const [publishingRelays, setPublishingRelays] = useState<string[]>([]);
-  const [relayStatus, setRelayStatus] = useState<RelayStatusMap>({});
+  const {
+    relayStatus,
+    publishingRelays,
+    initRelays,
+    onRelayComplete,
+    getFailedRelays,
+    setRelaysPending,
+    hasRelayErrors,
+    reset: resetRelayStatus,
+  } = useRelayPublishStatus();
   const [relayDetailsOpen, setRelayDetailsOpen] = useState(false);
   const [signedEventForRetry, setSignedEventForRetry] = useState<Event | null>(
     null,
@@ -381,7 +369,10 @@ export function CalendarEventEdit({
       : createDefaultCustomDraft(dayjs(eventDetails.begin)),
   );
 
-  const handleClose = onClose;
+  const handleClose = () => {
+    resetRelayStatus();
+    onClose();
+  };
 
   const theme = useTheme();
 
@@ -420,19 +411,8 @@ export function CalendarEventEdit({
   };
 
   const handleSave = async () => {
-    const relaysToPublish = normalizedRelayList();
-    const relayOutcomes: Record<string, boolean> = {};
-    const onRelayComplete = createRelayCompletionHandler(
-      relayOutcomes,
-      setRelayStatus,
-    );
-
-    setRelayStatus(
-      Object.fromEntries(
-        relaysToPublish.map((u) => [u, "pending" as const]),
-      ) as RelayStatusMap,
-    );
-    setPublishingRelays(relaysToPublish);
+    const relaysToPublish = getRelays();
+    initRelays(relaysToPublish);
     setSignedEventForRetry(null);
     setRelayDetailsOpen(false);
 
@@ -508,22 +488,17 @@ export function CalendarEventEdit({
         onSave(eventToSave);
       }
 
-      const allOk = relaysToPublish.every((u) => relayOutcomes[u] === true);
+      const allOk = getFailedRelays(relaysToPublish).length === 0;
       setProcessing(false);
       if (allOk) {
-        onClose();
+        handleClose();
       }
     } catch (e) {
       console.error(e instanceof Error ? e.message : "Unknown error");
-      setRelayStatus((prev) => {
-        const next = { ...prev };
-        for (const u of relaysToPublish) {
-          if (next[u] === "pending") {
-            next[u] = "error";
-          }
-        }
-        return next;
-      });
+      const failedRelays = getFailedRelays(relaysToPublish);
+      for (const relayUrl of failedRelays) {
+        onRelayComplete(relayUrl, false);
+      }
       setProcessing(false);
     }
   };
@@ -532,39 +507,28 @@ export function CalendarEventEdit({
     if (!signedEventForRetry) {
       return;
     }
-    const failed = publishingRelays.filter(
-      (u) => relayStatus[normalizeURL(u)] === "error",
-    );
+    const failed = getFailedRelays();
     if (failed.length === 0) {
       return;
     }
     setRetryingRelays(true);
-    setRelayStatus((prev) => {
-      const next = { ...prev };
-      for (const u of failed) {
-        const n = normalizeURL(u);
-        next[n] = "pending";
-      }
-      return next;
-    });
-    const outcomes: Record<string, boolean> = {};
-    const onComplete = createRelayCompletionHandler(outcomes, setRelayStatus);
+    setRelaysPending(failed);
     try {
       await republishEventToRelays(
         signedEventForRetry,
         failed,
         undefined,
-        onComplete,
+        onRelayComplete,
       );
     } catch {
-      // per-relay outcomes already set via onComplete where applicable
+      // per-relay outcomes already set via onRelayComplete where applicable
     } finally {
       setRetryingRelays(false);
     }
-    const retriedOk = failed.every((u) => outcomes[normalizeURL(u)] === true);
+    const retriedOk = getFailedRelays(failed).length === 0;
     if (retriedOk) {
       setRelayDetailsOpen(false);
-      onClose();
+      handleClose();
     }
   };
 
@@ -667,17 +631,17 @@ export function CalendarEventEdit({
     recurrenceValid
   );
 
-  const hasRelayErrors = publishingRelays.some(
-    (u) => relayStatus[normalizeURL(u)] === "error",
-  );
   const showRelayDetailsButton =
     hasRelayErrors && !processing && publishingRelays.length > 0;
   /** Save succeeded for the network, but at least one relay failed (event is already on the calendar). */
+  const hasRelaySuccess = publishingRelays.some((relayUrl) => {
+    return relayStatus[relayUrl] === "ok";
+  });
   const partialSaveRelayIssues =
     !processing &&
     publishingRelays.length > 0 &&
     hasRelayErrors &&
-    publishingRelays.some((u) => relayStatus[normalizeURL(u)] === "ok");
+    hasRelaySuccess;
 
   if (!open || !eventDetails) {
     return null;
@@ -1253,89 +1217,30 @@ export function CalendarEventEdit({
         style={{
           flex: 1,
           display: "flex",
-          flexDirection: "column",
           alignItems: "flex-start",
-          gap: 4,
           minWidth: 0,
         }}
       >
-        <Box
-          style={{ display: "flex", alignItems: "center", flexWrap: "wrap" }}
+        <IconButton
+          size="small"
+          onClick={() => useRelayStore.getState().updateRelayModal(true)}
         >
-          <IconButton
-            size="small"
-            onClick={() => useRelayStore.getState().updateRelayModal(true)}
-          >
-            <SettingsInputAntennaIcon fontSize="small" />
-          </IconButton>
-          <Typography variant="caption" color="textSecondary">
-            {intl.formatMessage(
-              { id: "event.publishingToRelays" },
-              { count: getRelays().length },
-            )}
-          </Typography>
-          {showRelayDetailsButton && !partialSaveRelayIssues && (
-            <Button
-              size="small"
-              sx={{ ml: 0.5, minWidth: "auto", p: 0.5, textTransform: "none" }}
-              onClick={() => setRelayDetailsOpen(true)}
-            >
-              {intl.formatMessage({ id: "event.relayDetails" })}
-            </Button>
+          <SettingsInputAntennaIcon fontSize="small" />
+        </IconButton>
+        <RelayDots
+          relays={publishingRelays}
+          relayStatus={relayStatus}
+          label={intl.formatMessage(
+            { id: "event.publishingToRelays" },
+            { count: getRelays().length },
           )}
-        </Box>
-        {publishingRelays.length > 0 && (
-          <Box
-            sx={{
-              display: "flex",
-              alignItems: "center",
-              flexWrap: "wrap",
-              gap: 0.5,
-              pl: 0.5,
-            }}
-          >
-            {publishingRelays.map((relayUrl) => {
-              const st = relayStatus[normalizeURL(relayUrl)] ?? "pending";
-              return (
-                <Tooltip key={relayUrl} title={relayUrl} arrow>
-                  <span>
-                    {st === "pending" && (
-                      <Box
-                        sx={{ display: "inline-flex", alignItems: "center" }}
-                      >
-                        <CircularProgress
-                          size={8}
-                          thickness={6}
-                          color="inherit"
-                        />
-                      </Box>
-                    )}
-                    {st === "ok" && (
-                      <Box
-                        sx={{
-                          width: 8,
-                          height: 8,
-                          borderRadius: "50%",
-                          bgcolor: "success.main",
-                        }}
-                      />
-                    )}
-                    {st === "error" && (
-                      <Box
-                        sx={{
-                          width: 8,
-                          height: 8,
-                          borderRadius: "50%",
-                          bgcolor: "error.main",
-                        }}
-                      />
-                    )}
-                  </span>
-                </Tooltip>
-              );
-            })}
-          </Box>
-        )}
+          onDetailsClick={
+            showRelayDetailsButton && !partialSaveRelayIssues
+              ? () => setRelayDetailsOpen(true)
+              : undefined
+          }
+          detailsLabel={intl.formatMessage({ id: "event.relayDetails" })}
+        />
       </Box>
       {partialSaveRelayIssues ? (
         <Box
@@ -1355,7 +1260,7 @@ export function CalendarEventEdit({
           >
             {intl.formatMessage({ id: "event.relayDetails" })}
           </Button>
-          <Button variant="outlined" onClick={onClose} color="primary">
+          <Button variant="outlined" onClick={handleClose} color="primary">
             {intl.formatMessage({ id: "event.closeEditor" })}
           </Button>
         </Box>

--- a/src/components/CalendarEventEdit.tsx
+++ b/src/components/CalendarEventEdit.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, type Dispatch, type SetStateAction } from "react";
 import {
   Dialog,
   DialogTitle,
@@ -17,6 +17,8 @@ import {
   Divider,
   useMediaQuery,
   useTheme,
+  Tooltip,
+  CircularProgress,
 } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
 import { ICalendarEvent, RepeatingFrequency } from "../utils/types";
@@ -29,10 +31,13 @@ import { ParticipantAdd } from "./ParticipantAdd";
 import { useIntl } from "react-intl";
 import ScheduleIcon from "@mui/icons-material/Schedule";
 import { Participant } from "./Participant";
+import type { Event } from "nostr-tools";
 import {
   editPrivateCalendarEvent,
+  getRelays,
   publishPrivateCalendarEvent,
   publishPublicCalendarEvent,
+  republishEventToRelays,
 } from "../common/nostr";
 import { EventKinds } from "../common/EventConfigs";
 import { DateTimePicker } from "@mui/x-date-pickers/DateTimePicker";
@@ -47,7 +52,6 @@ import { EventAttributeEditContainer } from "./StyledComponents";
 import LockIcon from "@mui/icons-material/Lock";
 import PublicIcon from "@mui/icons-material/Public";
 import SettingsInputAntennaIcon from "@mui/icons-material/SettingsInputAntenna";
-import { getRelays } from "../common/nostr";
 import { useRelayStore } from "../stores/relays";
 import { useCalendarLists } from "../stores/calendarLists";
 import { useTimeBasedEvents } from "../stores/events";
@@ -64,6 +68,31 @@ interface CalendarEventEditProps {
   onSave?: (event: ICalendarEvent) => void;
   mode?: "create" | "edit";
   display?: "modal" | "page";
+}
+
+type RelayLineStatus = "pending" | "ok" | "error";
+
+type RelayStatusMap = Record<string, RelayLineStatus>;
+
+function createRelayCompletionHandler(
+  outcomes: Record<string, boolean>,
+  setRelayStatus: Dispatch<SetStateAction<RelayStatusMap>>,
+) {
+  return (url: string, ok: boolean) => {
+    const n = normalizeURL(url);
+    outcomes[n] = ok;
+    setRelayStatus((prev) => ({ ...prev, [n]: ok ? "ok" : "error" }));
+  };
+}
+
+const PARTIAL_PUBLISH_NOTE_SX = {
+  pt: 2,
+  borderTop: 1,
+  borderColor: "divider" as const,
+};
+
+function normalizedRelayList(): string[] {
+  return Array.from(new Set(getRelays().map(normalizeURL)));
 }
 
 const CUSTOM_RECURRENCE_VALUE = "__custom_rule__";
@@ -279,10 +308,13 @@ export function CalendarEventEdit({
   const initialRecurrence = parseRecurrenceRule(initialRule);
   const initialIsCustom = !!initialRule && initialRecurrence.frequency === null;
   const [processing, setProcessing] = useState(false);
-  const [relayPublishOpen, setRelayPublishOpen] = useState(false);
   const [publishingRelays, setPublishingRelays] = useState<string[]>([]);
-  const [acceptedRelays, setAcceptedRelays] = useState<string[]>([]);
-  const [publishFailed, setPublishFailed] = useState(false);
+  const [relayStatus, setRelayStatus] = useState<RelayStatusMap>({});
+  const [relayDetailsOpen, setRelayDetailsOpen] = useState(false);
+  const [signedEventForRetry, setSignedEventForRetry] = useState<Event | null>(
+    null,
+  );
+  const [retryingRelays, setRetryingRelays] = useState(false);
   const [isPrivate, setIsPrivate] = useState(
     initialEvent?.isPrivateEvent ?? true,
   );
@@ -349,9 +381,7 @@ export function CalendarEventEdit({
       : createDefaultCustomDraft(dayjs(eventDetails.begin)),
   );
 
-  const handleClose = () => {
-    onClose();
-  };
+  const handleClose = onClose;
 
   const theme = useTheme();
 
@@ -389,24 +419,24 @@ export function CalendarEventEdit({
     setCustomDialogOpen(false);
   };
 
-  const handleAcceptedRelay = (url: string) => {
-    setAcceptedRelays((prev) => (prev.includes(url) ? prev : [...prev, url]));
-  };
-
   const handleSave = async () => {
-    const relaysToPublish = Array.from(new Set(getRelays().map(normalizeURL)));
-    const acceptedRelayUrls = new Set<string>();
-    const trackAcceptedRelay = (url: string) => {
-      const normalizedUrl = normalizeURL(url);
-      acceptedRelayUrls.add(normalizedUrl);
-      handleAcceptedRelay(normalizedUrl);
-    };
+    const relaysToPublish = normalizedRelayList();
+    const relayOutcomes: Record<string, boolean> = {};
+    const onRelayComplete = createRelayCompletionHandler(
+      relayOutcomes,
+      setRelayStatus,
+    );
+
+    setRelayStatus(
+      Object.fromEntries(
+        relaysToPublish.map((u) => [u, "pending" as const]),
+      ) as RelayStatusMap,
+    );
+    setPublishingRelays(relaysToPublish);
+    setSignedEventForRetry(null);
+    setRelayDetailsOpen(false);
 
     setProcessing(true);
-    setPublishingRelays(relaysToPublish);
-    setAcceptedRelays([]);
-    setPublishFailed(false);
-    setRelayPublishOpen(true);
     try {
       const rrule = isCustomRecurrence
         ? customRule
@@ -428,17 +458,22 @@ export function CalendarEventEdit({
           const updates = await editPrivateCalendarEvent(
             eventToSave,
             selectedCalendarId,
-            trackAcceptedRelay,
+            undefined,
+            onRelayComplete,
           );
+          setSignedEventForRetry(updates.signedEvent);
 
           useTimeBasedEvents
             .getState()
             .updateEvent({ ...updates.event, calendarId: updates.calendarId });
         } else {
-          const { eventRef, authorPubkey } = await publishPrivateCalendarEvent(
-            eventToSave,
-            trackAcceptedRelay,
-          );
+          const { eventRef, authorPubkey, calendarEvent } =
+            await publishPrivateCalendarEvent(
+              eventToSave,
+              undefined,
+              onRelayComplete,
+            );
+          setSignedEventForRetry(calendarEvent);
           await addEventToCalendar(selectedCalendarId, eventRef);
           const { eventDTag, viewKey } = parseEventRef(eventRef);
           useTimeBasedEvents.getState().addEvent({
@@ -450,10 +485,16 @@ export function CalendarEventEdit({
           });
         }
       } else {
-        const { id: savedId, pubKey } = await publishPublicCalendarEvent(
+        const {
+          id: savedId,
+          pubKey,
+          signedEvent,
+        } = await publishPublicCalendarEvent(
           eventToSave,
-          trackAcceptedRelay,
+          undefined,
+          onRelayComplete,
         );
+        setSignedEventForRetry(signedEvent);
         useTimeBasedEvents.getState().updateEvent({
           ...eventToSave,
           id: savedId,
@@ -467,20 +508,62 @@ export function CalendarEventEdit({
         onSave(eventToSave);
       }
 
+      const allOk = relaysToPublish.every((u) => relayOutcomes[u] === true);
       setProcessing(false);
-      if (acceptedRelayUrls.size < relaysToPublish.length) {
-        setPublishFailed(true);
+      if (allOk) {
+        onClose();
       }
     } catch (e) {
       console.error(e instanceof Error ? e.message : "Unknown error");
-      setPublishFailed(true);
+      setRelayStatus((prev) => {
+        const next = { ...prev };
+        for (const u of relaysToPublish) {
+          if (next[u] === "pending") {
+            next[u] = "error";
+          }
+        }
+        return next;
+      });
       setProcessing(false);
     }
   };
 
-  const handlePublishDialogClose = () => {
-    setRelayPublishOpen(false);
-    if (!publishFailed) {
+  const handleRetryFailedRelays = async () => {
+    if (!signedEventForRetry) {
+      return;
+    }
+    const failed = publishingRelays.filter(
+      (u) => relayStatus[normalizeURL(u)] === "error",
+    );
+    if (failed.length === 0) {
+      return;
+    }
+    setRetryingRelays(true);
+    setRelayStatus((prev) => {
+      const next = { ...prev };
+      for (const u of failed) {
+        const n = normalizeURL(u);
+        next[n] = "pending";
+      }
+      return next;
+    });
+    const outcomes: Record<string, boolean> = {};
+    const onComplete = createRelayCompletionHandler(outcomes, setRelayStatus);
+    try {
+      await republishEventToRelays(
+        signedEventForRetry,
+        failed,
+        undefined,
+        onComplete,
+      );
+    } catch {
+      // per-relay outcomes already set via onComplete where applicable
+    } finally {
+      setRetryingRelays(false);
+    }
+    const retriedOk = failed.every((u) => outcomes[normalizeURL(u)] === true);
+    if (retriedOk) {
+      setRelayDetailsOpen(false);
       onClose();
     }
   };
@@ -583,6 +666,18 @@ export function CalendarEventEdit({
     eventDetails.begin < eventDetails.end &&
     recurrenceValid
   );
+
+  const hasRelayErrors = publishingRelays.some(
+    (u) => relayStatus[normalizeURL(u)] === "error",
+  );
+  const showRelayDetailsButton =
+    hasRelayErrors && !processing && publishingRelays.length > 0;
+  /** Save succeeded for the network, but at least one relay failed (event is already on the calendar). */
+  const partialSaveRelayIssues =
+    !processing &&
+    publishingRelays.length > 0 &&
+    hasRelayErrors &&
+    publishingRelays.some((u) => relayStatus[normalizeURL(u)] === "ok");
 
   if (!open || !eventDetails) {
     return null;
@@ -1074,7 +1169,10 @@ export function CalendarEventEdit({
                     borderRadius: 4,
                   }}
                 >
-                  <Participant pubKey={participant} />
+                  <Participant
+                    pubKey={participant}
+                    isAuthor={participant === eventDetails.user}
+                  />
                   <Button
                     size="small"
                     color="error"
@@ -1155,35 +1253,158 @@ export function CalendarEventEdit({
         style={{
           flex: 1,
           display: "flex",
-          alignItems: "center",
+          flexDirection: "column",
+          alignItems: "flex-start",
+          gap: 4,
+          minWidth: 0,
         }}
       >
-        <IconButton
-          size="small"
-          onClick={() => useRelayStore.getState().updateRelayModal(true)}
+        <Box
+          style={{ display: "flex", alignItems: "center", flexWrap: "wrap" }}
         >
-          <SettingsInputAntennaIcon fontSize="small" />
-        </IconButton>
-        <Typography variant="caption" color="textSecondary">
-          {intl.formatMessage(
-            { id: "event.publishingToRelays" },
-            { count: getRelays().length },
+          <IconButton
+            size="small"
+            onClick={() => useRelayStore.getState().updateRelayModal(true)}
+          >
+            <SettingsInputAntennaIcon fontSize="small" />
+          </IconButton>
+          <Typography variant="caption" color="textSecondary">
+            {intl.formatMessage(
+              { id: "event.publishingToRelays" },
+              { count: getRelays().length },
+            )}
+          </Typography>
+          {showRelayDetailsButton && !partialSaveRelayIssues && (
+            <Button
+              size="small"
+              sx={{ ml: 0.5, minWidth: "auto", p: 0.5, textTransform: "none" }}
+              onClick={() => setRelayDetailsOpen(true)}
+            >
+              {intl.formatMessage({ id: "event.relayDetails" })}
+            </Button>
           )}
-        </Typography>
+        </Box>
+        {publishingRelays.length > 0 && (
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              flexWrap: "wrap",
+              gap: 0.5,
+              pl: 0.5,
+            }}
+          >
+            {publishingRelays.map((relayUrl) => {
+              const st = relayStatus[normalizeURL(relayUrl)] ?? "pending";
+              return (
+                <Tooltip key={relayUrl} title={relayUrl} arrow>
+                  <span>
+                    {st === "pending" && (
+                      <Box
+                        sx={{ display: "inline-flex", alignItems: "center" }}
+                      >
+                        <CircularProgress
+                          size={8}
+                          thickness={6}
+                          color="inherit"
+                        />
+                      </Box>
+                    )}
+                    {st === "ok" && (
+                      <Box
+                        sx={{
+                          width: 8,
+                          height: 8,
+                          borderRadius: "50%",
+                          bgcolor: "success.main",
+                        }}
+                      />
+                    )}
+                    {st === "error" && (
+                      <Box
+                        sx={{
+                          width: 8,
+                          height: 8,
+                          borderRadius: "50%",
+                          bgcolor: "error.main",
+                        }}
+                      />
+                    )}
+                  </span>
+                </Tooltip>
+              );
+            })}
+          </Box>
+        )}
       </Box>
-      <Button onClick={handleClose} color="inherit">
-        {intl.formatMessage({ id: "navigation.cancel" })}
-      </Button>
-      <Button
-        onClick={handleSave}
-        variant="contained"
-        disabled={buttonDisabled}
-      >
-        {processing
-          ? intl.formatMessage({ id: "event.saving" })
-          : intl.formatMessage({ id: "event.saveEvent" })}
-      </Button>
+      {partialSaveRelayIssues ? (
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            gap: 1,
+            flexWrap: "wrap",
+            justifyContent: "flex-end",
+          }}
+        >
+          <Button
+            variant="contained"
+            onClick={() => setRelayDetailsOpen(true)}
+            disabled={!signedEventForRetry}
+            color="primary"
+          >
+            {intl.formatMessage({ id: "event.relayDetails" })}
+          </Button>
+          <Button variant="outlined" onClick={onClose} color="primary">
+            {intl.formatMessage({ id: "event.closeEditor" })}
+          </Button>
+        </Box>
+      ) : (
+        <>
+          <Button onClick={handleClose} color="inherit">
+            {intl.formatMessage({ id: "navigation.cancel" })}
+          </Button>
+          <Button
+            onClick={handleSave}
+            variant="contained"
+            disabled={buttonDisabled}
+          >
+            {processing
+              ? intl.formatMessage({ id: "event.saving" })
+              : intl.formatMessage({ id: "event.saveEvent" })}
+          </Button>
+        </>
+      )}
     </>
+  );
+
+  const partialPublishNote = partialSaveRelayIssues ? (
+    <Box sx={PARTIAL_PUBLISH_NOTE_SX}>
+      <Typography
+        variant="body2"
+        color="text.secondary"
+        sx={{ lineHeight: 1.5 }}
+      >
+        <Box component="span" sx={{ fontWeight: 600, color: "text.primary" }}>
+          {intl.formatMessage({ id: "event.note" })}:{" "}
+        </Box>
+        {intl.formatMessage({ id: "event.partialPublishHint" })}
+      </Typography>
+    </Box>
+  ) : null;
+
+  const canShowRelayRetry =
+    hasRelayErrors && !!signedEventForRetry && publishingRelays.length > 0;
+  const relayPublishDialog = (
+    <RelayPublishDialog
+      open={relayDetailsOpen}
+      relays={publishingRelays}
+      relayStatus={relayStatus}
+      onClose={() => setRelayDetailsOpen(false)}
+      onRetry={handleRetryFailedRelays}
+      retrying={retryingRelays}
+      showRetry={canShowRelayRetry}
+    />
   );
 
   if (display === "page") {
@@ -1198,6 +1419,7 @@ export function CalendarEventEdit({
         >
           <Box style={{ marginBottom: 24 }}>{titleBar}</Box>
           <Box style={{ marginBottom: 24 }}>{formContent}</Box>
+          {partialPublishNote}
           <Box
             style={{
               display: "flex",
@@ -1210,13 +1432,7 @@ export function CalendarEventEdit({
             {actions}
           </Box>
         </Box>
-        <RelayPublishDialog
-          open={relayPublishOpen}
-          relays={publishingRelays}
-          acceptedRelays={acceptedRelays}
-          publishFailed={publishFailed}
-          onClose={handlePublishDialogClose}
-        />
+        {relayPublishDialog}
       </>
     );
   }
@@ -1231,16 +1447,13 @@ export function CalendarEventEdit({
         fullWidth
       >
         <DialogTitle>{titleBar}</DialogTitle>
-        <DialogContent dividers>{formContent}</DialogContent>
+        <DialogContent dividers>
+          {formContent}
+          {partialPublishNote}
+        </DialogContent>
         <DialogActions style={{ padding: 16 }}>{actions}</DialogActions>
       </Dialog>
-      <RelayPublishDialog
-        open={relayPublishOpen}
-        relays={publishingRelays}
-        acceptedRelays={acceptedRelays}
-        publishFailed={publishFailed}
-        onClose={handlePublishDialogClose}
-      />
+      {relayPublishDialog}
     </>
   );
 }

--- a/src/components/RelayDots.tsx
+++ b/src/components/RelayDots.tsx
@@ -1,0 +1,105 @@
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import { normalizeURL } from "nostr-tools/utils";
+import type { RelayStatusMap } from "../utils/types";
+
+interface RelayDotsProps {
+  relays: string[];
+  relayStatus: RelayStatusMap;
+  label: string;
+  onDetailsClick?: () => void;
+  detailsLabel?: string;
+}
+
+export function RelayDots({
+  relays,
+  relayStatus,
+  label,
+  onDetailsClick,
+  detailsLabel,
+}: RelayDotsProps) {
+  const normalizedRelays = Array.from(new Set(relays.map(normalizeURL)));
+
+  return (
+    <Box
+      style={{
+        flex: 1,
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "flex-start",
+        gap: 4,
+        minWidth: 0,
+      }}
+    >
+      <Box style={{ display: "flex", alignItems: "center", flexWrap: "wrap" }}>
+        <Typography variant="caption" color="textSecondary">
+          {label}
+        </Typography>
+        {onDetailsClick && detailsLabel && (
+          <Button
+            size="small"
+            sx={{ ml: 0.5, minWidth: "auto", p: 0.5, textTransform: "none" }}
+            onClick={onDetailsClick}
+          >
+            {detailsLabel}
+          </Button>
+        )}
+      </Box>
+      {normalizedRelays.length > 0 && (
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            flexWrap: "wrap",
+            gap: 0.5,
+            pl: 0.5,
+          }}
+        >
+          {normalizedRelays.map((relayUrl) => {
+            const status = relayStatus[relayUrl] ?? "pending";
+            return (
+              <Tooltip key={relayUrl} title={relayUrl} arrow>
+                <span>
+                  {status === "pending" && (
+                    <Box sx={{ display: "inline-flex", alignItems: "center" }}>
+                      <CircularProgress
+                        size={8}
+                        thickness={6}
+                        color="inherit"
+                      />
+                    </Box>
+                  )}
+                  {status === "ok" && (
+                    <Box
+                      sx={{
+                        width: 8,
+                        height: 8,
+                        borderRadius: "50%",
+                        bgcolor: "success.main",
+                      }}
+                    />
+                  )}
+                  {status === "error" && (
+                    <Box
+                      sx={{
+                        width: 8,
+                        height: 8,
+                        borderRadius: "50%",
+                        bgcolor: "error.main",
+                      }}
+                    />
+                  )}
+                </span>
+              </Tooltip>
+            );
+          })}
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/src/components/RelayPublishDialog.tsx
+++ b/src/components/RelayPublishDialog.tsx
@@ -1,0 +1,109 @@
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Typography,
+} from "@mui/material";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import ErrorIcon from "@mui/icons-material/Error";
+import { normalizeURL } from "nostr-tools/utils";
+import { useIntl } from "react-intl";
+
+interface RelayPublishDialogProps {
+  open: boolean;
+  relays: string[];
+  acceptedRelays: string[];
+  publishFailed?: boolean;
+  onClose?: () => void;
+}
+
+export function RelayPublishDialog({
+  open,
+  relays,
+  acceptedRelays,
+  publishFailed = false,
+  onClose,
+}: RelayPublishDialogProps) {
+  const intl = useIntl();
+  const normalizedAcceptedRelays = new Set(acceptedRelays.map(normalizeURL));
+  const normalizedRelays = Array.from(new Set(relays.map(normalizeURL)));
+  const allRelaysAccepted =
+    normalizedRelays.length > 0 &&
+    normalizedRelays.every((url) => normalizedAcceptedRelays.has(url));
+  const canClose = allRelaysAccepted || publishFailed;
+
+  return (
+    <Dialog
+      open={open}
+      onClose={canClose ? onClose : undefined}
+      maxWidth="sm"
+      fullWidth
+    >
+      <DialogTitle>
+        {intl.formatMessage({ id: "event.publishingEvent" })}
+      </DialogTitle>
+      <DialogContent dividers>
+        {allRelaysAccepted && (
+          <Box
+            sx={{
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              gap: 1.5,
+              py: 3,
+            }}
+          >
+            <CheckCircleIcon sx={{ color: "success.main", fontSize: 96 }} />
+            <Typography variant="h6" fontWeight={600} textAlign="center">
+              {intl.formatMessage({ id: "event.eventSaved" })}
+            </Typography>
+          </Box>
+        )}
+        <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 2 }}>
+          {intl.formatMessage(
+            { id: "event.relaysPublishStatus" },
+            { complete: allRelaysAccepted ? " (Complete)" : "" },
+          )}
+        </Typography>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 1.25 }}>
+          {normalizedRelays.map((url) => {
+            const isAccepted = normalizedAcceptedRelays.has(url);
+            const showFailed = publishFailed && !isAccepted;
+
+            return (
+              <Box
+                key={url}
+                sx={{ display: "flex", alignItems: "center", gap: 1 }}
+              >
+                {isAccepted ? (
+                  <CheckCircleIcon sx={{ color: "success.main" }} />
+                ) : showFailed ? (
+                  <ErrorIcon sx={{ color: "error.main" }} />
+                ) : (
+                  <CircularProgress size={20} />
+                )}
+                <Typography variant="body2">{url}</Typography>
+              </Box>
+            );
+          })}
+        </Box>
+        {publishFailed && normalizedAcceptedRelays.size === 0 && (
+          <Typography color="error" variant="body2" sx={{ mt: 2 }}>
+            {intl.formatMessage({ id: "event.noRelaysAccepted" })}
+          </Typography>
+        )}
+      </DialogContent>
+      {canClose && (
+        <DialogActions>
+          <Button onClick={onClose} variant="contained">
+            {intl.formatMessage({ id: "navigation.close" })}
+          </Button>
+        </DialogActions>
+      )}
+    </Dialog>
+  );
+}

--- a/src/components/RelayPublishDialog.tsx
+++ b/src/components/RelayPublishDialog.tsx
@@ -13,75 +13,63 @@ import ErrorIcon from "@mui/icons-material/Error";
 import { normalizeURL } from "nostr-tools/utils";
 import { useIntl } from "react-intl";
 
+type RelayKeyStatus = "pending" | "ok" | "error";
+
 interface RelayPublishDialogProps {
   open: boolean;
   relays: string[];
-  acceptedRelays: string[];
-  publishFailed?: boolean;
-  onClose?: () => void;
+  /** Keys must be normalizeURL(relay) */
+  relayStatus: Record<string, RelayKeyStatus | undefined>;
+  onClose: () => void;
+  /** Re-publish only to relays that did not accept */
+  onRetry?: () => void | Promise<void>;
+  retrying?: boolean;
+  showRetry?: boolean;
+}
+
+function statusForUrl(
+  url: string,
+  relayStatus: Record<string, RelayKeyStatus | undefined>,
+): RelayKeyStatus {
+  const n = normalizeURL(url);
+  return relayStatus[n] ?? "pending";
 }
 
 export function RelayPublishDialog({
   open,
   relays,
-  acceptedRelays,
-  publishFailed = false,
+  relayStatus,
   onClose,
+  onRetry,
+  retrying = false,
+  showRetry = false,
 }: RelayPublishDialogProps) {
   const intl = useIntl();
-  const normalizedAcceptedRelays = new Set(acceptedRelays.map(normalizeURL));
   const normalizedRelays = Array.from(new Set(relays.map(normalizeURL)));
-  const allRelaysAccepted =
-    normalizedRelays.length > 0 &&
-    normalizedRelays.every((url) => normalizedAcceptedRelays.has(url));
-  const canClose = allRelaysAccepted || publishFailed;
 
   return (
-    <Dialog
-      open={open}
-      onClose={canClose ? onClose : undefined}
-      maxWidth="sm"
-      fullWidth
-    >
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
       <DialogTitle>
         {intl.formatMessage({ id: "event.publishingEvent" })}
       </DialogTitle>
       <DialogContent dividers>
-        {allRelaysAccepted && (
-          <Box
-            sx={{
-              display: "flex",
-              flexDirection: "column",
-              alignItems: "center",
-              gap: 1.5,
-              py: 3,
-            }}
-          >
-            <CheckCircleIcon sx={{ color: "success.main", fontSize: 96 }} />
-            <Typography variant="h6" fontWeight={600} textAlign="center">
-              {intl.formatMessage({ id: "event.eventSaved" })}
-            </Typography>
-          </Box>
-        )}
         <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 2 }}>
           {intl.formatMessage(
             { id: "event.relaysPublishStatus" },
-            { complete: allRelaysAccepted ? " (Complete)" : "" },
+            { complete: "" },
           )}
         </Typography>
         <Box sx={{ display: "flex", flexDirection: "column", gap: 1.25 }}>
           {normalizedRelays.map((url) => {
-            const isAccepted = normalizedAcceptedRelays.has(url);
-            const showFailed = publishFailed && !isAccepted;
-
+            const st = statusForUrl(url, relayStatus);
             return (
               <Box
                 key={url}
                 sx={{ display: "flex", alignItems: "center", gap: 1 }}
               >
-                {isAccepted ? (
+                {st === "ok" ? (
                   <CheckCircleIcon sx={{ color: "success.main" }} />
-                ) : showFailed ? (
+                ) : st === "error" ? (
                   <ErrorIcon sx={{ color: "error.main" }} />
                 ) : (
                   <CircularProgress size={20} />
@@ -91,19 +79,30 @@ export function RelayPublishDialog({
             );
           })}
         </Box>
-        {publishFailed && normalizedAcceptedRelays.size === 0 && (
+        {showRetry && (
           <Typography color="error" variant="body2" sx={{ mt: 2 }}>
-            {intl.formatMessage({ id: "event.noRelaysAccepted" })}
+            {intl.formatMessage({ id: "event.relayPartialFailure" })}
           </Typography>
         )}
       </DialogContent>
-      {canClose && (
-        <DialogActions>
-          <Button onClick={onClose} variant="contained">
-            {intl.formatMessage({ id: "navigation.close" })}
+      <DialogActions sx={{ gap: 1, pr: 2, pb: 2 }}>
+        {showRetry && onRetry && (
+          <Button
+            onClick={onRetry}
+            variant="contained"
+            color="primary"
+            disabled={retrying}
+            startIcon={
+              retrying ? <CircularProgress size={16} color="inherit" /> : null
+            }
+          >
+            {intl.formatMessage({ id: "event.retryFailedRelays" })}
           </Button>
-        </DialogActions>
-      )}
+        )}
+        <Button onClick={onClose} variant="outlined" disabled={retrying}>
+          {intl.formatMessage({ id: "navigation.close" })}
+        </Button>
+      </DialogActions>
     </Dialog>
   );
 }

--- a/src/components/RelayPublishDialog.tsx
+++ b/src/components/RelayPublishDialog.tsx
@@ -12,14 +12,13 @@ import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import ErrorIcon from "@mui/icons-material/Error";
 import { normalizeURL } from "nostr-tools/utils";
 import { useIntl } from "react-intl";
-
-type RelayKeyStatus = "pending" | "ok" | "error";
+import type { RelayLineStatus, RelayStatusMap } from "../utils/types";
 
 interface RelayPublishDialogProps {
   open: boolean;
   relays: string[];
   /** Keys must be normalizeURL(relay) */
-  relayStatus: Record<string, RelayKeyStatus | undefined>;
+  relayStatus: RelayStatusMap;
   onClose: () => void;
   /** Re-publish only to relays that did not accept */
   onRetry?: () => void | Promise<void>;
@@ -29,8 +28,8 @@ interface RelayPublishDialogProps {
 
 function statusForUrl(
   url: string,
-  relayStatus: Record<string, RelayKeyStatus | undefined>,
-): RelayKeyStatus {
+  relayStatus: RelayStatusMap,
+): RelayLineStatus {
   const n = normalizeURL(url);
   return relayStatus[n] ?? "pending";
 }

--- a/src/hooks/useRelayPublishStatus.ts
+++ b/src/hooks/useRelayPublishStatus.ts
@@ -1,0 +1,79 @@
+import { useCallback, useMemo, useRef, useState } from "react";
+import { normalizeURL } from "nostr-tools/utils";
+import type { RelayStatusMap } from "../utils/types";
+
+function normalizeRelays(relays: string[]): string[] {
+  return Array.from(new Set(relays.map(normalizeURL)));
+}
+
+export function useRelayPublishStatus() {
+  const [relayStatus, setRelayStatus] = useState<RelayStatusMap>({});
+  const [publishingRelays, setPublishingRelays] = useState<string[]>([]);
+  const outcomesRef = useRef<Record<string, boolean>>({});
+
+  const initRelays = useCallback((relays: string[]) => {
+    const normalized = normalizeRelays(relays);
+    outcomesRef.current = Object.fromEntries(
+      normalized.map((relayUrl) => [relayUrl, false]),
+    );
+    setPublishingRelays(normalized);
+    setRelayStatus(
+      Object.fromEntries(
+        normalized.map((relayUrl) => [relayUrl, "pending" as const]),
+      ) as RelayStatusMap,
+    );
+  }, []);
+
+  const onRelayComplete = useCallback((url: string, ok: boolean) => {
+    const normalized = normalizeURL(url);
+    outcomesRef.current[normalized] = ok;
+    setRelayStatus((prev) => ({
+      ...prev,
+      [normalized]: ok ? "ok" : "error",
+    }));
+  }, []);
+
+  const getFailedRelays = useCallback(
+    (relays?: string[]) => {
+      const targetRelays = relays ? normalizeRelays(relays) : publishingRelays;
+      return targetRelays.filter(
+        (relayUrl) => outcomesRef.current[relayUrl] !== true,
+      );
+    },
+    [publishingRelays],
+  );
+
+  const setRelaysPending = useCallback((relays: string[]) => {
+    const normalized = normalizeRelays(relays);
+    setRelayStatus((prev) => {
+      const next = { ...prev };
+      for (const relayUrl of normalized) {
+        next[relayUrl] = "pending";
+        outcomesRef.current[relayUrl] = false;
+      }
+      return next;
+    });
+  }, []);
+
+  const hasRelayErrors = useMemo(
+    () => Object.values(relayStatus).some((status) => status === "error"),
+    [relayStatus],
+  );
+
+  const reset = useCallback(() => {
+    outcomesRef.current = {};
+    setRelayStatus({});
+    setPublishingRelays([]);
+  }, []);
+
+  return {
+    relayStatus,
+    publishingRelays,
+    initRelays,
+    onRelayComplete,
+    getFailedRelays,
+    setRelaysPending,
+    hasRelayErrors,
+    reset,
+  };
+}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -35,6 +35,9 @@ export interface IScheduledNotification {
 
 export type NotificationPreference = "enabled" | "disabled";
 
+export type RelayLineStatus = "pending" | "ok" | "error";
+export type RelayStatusMap = Record<string, RelayLineStatus>;
+
 export interface ICalendarEvent {
   begin: number;
   description: string;


### PR DESCRIPTION
## Summary

Fixes : #117 


Adds a relay publish progress dialog when saving calendar events. Each relay shows its publish state, with green checks for accepted relays and errors for failed relays.

Also adds a success state once publishing completes.

## Demo
[relay.webm](https://github.com/user-attachments/assets/5f37e5f6-05a9-4a05-98c7-fc5098488fd7)

## Success mark
<img width="1862" height="920" alt="image" src="https://github.com/user-attachments/assets/6543be6d-56fd-44a5-bfc9-ae1cebc27d89" />

