### PR TITLE
feat(device-calendar): add read-only Android calendar integration

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -92,4 +92,5 @@
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
+    <uses-permission android:name="android.permission.READ_CALENDAR"/>
 </manifest>

--- a/android/app/src/main/java/app/formstr/calendar/DeviceCalendarPlugin.java
+++ b/android/app/src/main/java/app/formstr/calendar/DeviceCalendarPlugin.java
@@ -1,0 +1,277 @@
+package app.formstr.calendar;
+
+import android.Manifest;
+import android.content.ContentResolver;
+import android.content.ContentUris;
+import android.content.Intent;
+import android.database.Cursor;
+import android.net.Uri;
+import android.provider.CalendarContract;
+import android.provider.Settings;
+import android.text.TextUtils;
+import android.util.Log;
+
+import com.getcapacitor.JSArray;
+import com.getcapacitor.JSObject;
+import com.getcapacitor.PermissionState;
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.CapacitorPlugin;
+import com.getcapacitor.annotation.Permission;
+import com.getcapacitor.annotation.PermissionCallback;
+
+import org.json.JSONException;
+
+import java.util.Locale;
+/**
+ * Bridges the device's calendar database to the JS layer. Read-only.
+ */
+@CapacitorPlugin(
+        name = "DeviceCalendar",
+        permissions = {
+                @Permission(
+                        alias = DeviceCalendarPlugin.PERM_ALIAS,
+                        strings = {
+                                Manifest.permission.READ_CALENDAR
+                        }
+                )
+        }
+)
+public class DeviceCalendarPlugin extends Plugin {
+
+    private static final String TAG = "DeviceCalendarPlugin";
+    static final String PERM_ALIAS = "calendar";
+
+    @PluginMethod
+    public void checkPermissions(PluginCall call) {
+        call.resolve(buildPermissionStatus());
+    }
+
+    @Override
+    @PluginMethod
+    public void requestPermissions(PluginCall call) {
+        if (currentPermissionState() == PermissionState.GRANTED) {
+            call.resolve(buildPermissionStatus());
+            return;
+        }
+        requestPermissionForAlias(PERM_ALIAS, call, "permissionCallback");
+    }
+
+    @PermissionCallback
+    private void permissionCallback(PluginCall call) {
+        call.resolve(buildPermissionStatus());
+    }
+
+    @PluginMethod
+    public void listCalendars(PluginCall call) {
+        if (currentPermissionState() != PermissionState.GRANTED) {
+            call.reject("Calendar permission not granted");
+            return;
+        }
+
+        JSArray calendars = new JSArray();
+        String[] projection = new String[]{
+                CalendarContract.Calendars._ID,
+                CalendarContract.Calendars.CALENDAR_DISPLAY_NAME,
+                CalendarContract.Calendars.ACCOUNT_NAME,
+                CalendarContract.Calendars.CALENDAR_COLOR,
+                CalendarContract.Calendars.CALENDAR_ACCESS_LEVEL,
+                CalendarContract.Calendars.IS_PRIMARY,
+                CalendarContract.Calendars.OWNER_ACCOUNT,
+        };
+
+        ContentResolver resolver = getContext().getContentResolver();
+        // Only surface calendars the user has chosen to show in the system
+        // Calendar app and that are actively syncing events. This drops
+        // Classroom-style auto-synced calendars the user never opted in to.
+        String selection = CalendarContract.Calendars.VISIBLE + " = 1 AND "
+                + CalendarContract.Calendars.SYNC_EVENTS + " = 1";
+        try (Cursor cursor = resolver.query(
+                CalendarContract.Calendars.CONTENT_URI,
+                projection,
+                selection,
+                null,
+                CalendarContract.Calendars.CALENDAR_DISPLAY_NAME + " ASC")) {
+            if (cursor == null) {
+                call.resolve(new JSObject().put("calendars", calendars));
+                return;
+            }
+            while (cursor.moveToNext()) {
+                long id = cursor.getLong(0);
+                String name = cursor.getString(1);
+                String accountName = cursor.getString(2);
+                int color = cursor.getInt(3);
+                int accessLevel = cursor.getInt(4);
+                boolean isPrimary = !cursor.isNull(5) && cursor.getInt(5) == 1;
+
+                JSObject obj = new JSObject();
+                obj.put("id", String.valueOf(id));
+                obj.put("name", TextUtils.isEmpty(name) ? "(Unnamed)" : name);
+                obj.put("accountName", accountName == null ? "" : accountName);
+                obj.put("color", colorIntToHex(color));
+                obj.put("isPrimary", isPrimary);
+                obj.put("canWrite", accessLevel >= CalendarContract.Calendars.CAL_ACCESS_CONTRIBUTOR);
+                calendars.put(obj);
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "listCalendars failed", e);
+            call.reject("Failed to read calendars: " + e.getMessage());
+            return;
+        }
+
+        JSObject result = new JSObject();
+        result.put("calendars", calendars);
+        call.resolve(result);
+    }
+
+    @PluginMethod
+    public void listEvents(PluginCall call) {
+        if (currentPermissionState() != PermissionState.GRANTED) {
+            call.reject("Calendar permission not granted");
+            return;
+        }
+
+        Long startMs = call.getLong("startMs");
+        Long endMs = call.getLong("endMs");
+        if (startMs == null || endMs == null || endMs <= startMs) {
+            call.reject("startMs and endMs are required, and endMs must be > startMs");
+            return;
+        }
+
+        JSArray calendarIdsArray = call.getArray("calendarIds", new JSArray());
+        String filterClause = null;
+        try {
+            if (calendarIdsArray != null && calendarIdsArray.length() > 0) {
+                StringBuilder sb = new StringBuilder();
+                sb.append(CalendarContract.Instances.CALENDAR_ID).append(" IN (");
+                for (int i = 0; i < calendarIdsArray.length(); i++) {
+                    if (i > 0) sb.append(",");
+                    // Casting to long sanitizes the input.
+                    sb.append(Long.parseLong(calendarIdsArray.getString(i)));
+                }
+                sb.append(")");
+                filterClause = sb.toString();
+            }
+        } catch (JSONException | NumberFormatException e) {
+            call.reject("Invalid calendarIds payload");
+            return;
+        }
+
+        // Use the Instances table so the OS expands recurring events for us.
+        Uri.Builder builder = CalendarContract.Instances.CONTENT_URI.buildUpon();
+        ContentUris.appendId(builder, startMs);
+        ContentUris.appendId(builder, endMs);
+
+        String[] projection = new String[]{
+                CalendarContract.Instances._ID,
+                CalendarContract.Instances.EVENT_ID,
+                CalendarContract.Instances.CALENDAR_ID,
+                CalendarContract.Instances.TITLE,
+                CalendarContract.Instances.DESCRIPTION,
+                CalendarContract.Instances.EVENT_LOCATION,
+                CalendarContract.Instances.BEGIN,
+                CalendarContract.Instances.END,
+                CalendarContract.Instances.ALL_DAY,
+                CalendarContract.Instances.ORGANIZER,
+                CalendarContract.Instances.RRULE,
+        };
+
+        JSArray events = new JSArray();
+        ContentResolver resolver = getContext().getContentResolver();
+        try (Cursor cursor = resolver.query(
+                builder.build(),
+                projection,
+                filterClause,
+                null,
+                CalendarContract.Instances.BEGIN + " ASC")) {
+            if (cursor == null) {
+                call.resolve(new JSObject().put("events", events));
+                return;
+            }
+            while (cursor.moveToNext()) {
+                long instanceId = cursor.getLong(0);
+                long eventId = cursor.getLong(1);
+                long calendarId = cursor.getLong(2);
+                String title = cursor.getString(3);
+                String description = cursor.getString(4);
+                String location = cursor.getString(5);
+                long begin = cursor.getLong(6);
+                long end = cursor.getLong(7);
+                boolean allDay = cursor.getInt(8) == 1;
+                String organizer = cursor.getString(9);
+                String rrule = cursor.getString(10);
+
+                JSObject obj = new JSObject();
+                // Combine instance + event id so duplicate occurrences of the same recurring
+                // event remain distinct as React render keys.
+                obj.put("id", instanceId + ":" + eventId);
+                obj.put("calendarId", String.valueOf(calendarId));
+                obj.put("title", title == null ? "" : title);
+                obj.put("description", description == null ? "" : description);
+                obj.put("location", location == null ? "" : location);
+                obj.put("beginMs", begin);
+                obj.put("endMs", end);
+                obj.put("allDay", allDay);
+                obj.put("organizer", organizer == null ? "" : organizer);
+                if (!TextUtils.isEmpty(rrule)) {
+                    obj.put("rrule", rrule);
+                }
+                events.put(obj);
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "listEvents failed", e);
+            call.reject("Failed to read events: " + e.getMessage());
+            return;
+        }
+
+        JSObject result = new JSObject();
+        result.put("events", events);
+        call.resolve(result);
+    }
+
+    /**
+     * Opens the app's system settings page so the user can flip calendar
+     * permission back on after Android has stopped surfacing the runtime
+     * dialog (repeated denial / "don't ask again").
+     */
+    @PluginMethod
+    public void openAppSettings(PluginCall call) {
+        try {
+            Intent intent = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
+            intent.setData(Uri.fromParts("package", getContext().getPackageName(), null));
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            getContext().startActivity(intent);
+            call.resolve();
+        } catch (Exception e) {
+            Log.e(TAG, "openAppSettings failed", e);
+            call.reject("Failed to open app settings: " + e.getMessage());
+        }
+    }
+
+    private PermissionState currentPermissionState() {
+        return getPermissionState(PERM_ALIAS);
+    }
+
+    private JSObject buildPermissionStatus() {
+        JSObject status = new JSObject();
+        status.put("calendar", capacitorStateString(currentPermissionState()));
+        return status;
+    }
+
+    private static String capacitorStateString(PermissionState state) {
+        if (state == null) return "prompt";
+        switch (state) {
+            case GRANTED: return "granted";
+            case DENIED:  return "denied";
+            case PROMPT_WITH_RATIONALE: return "prompt-with-rationale";
+            case PROMPT:
+            default: return "prompt";
+        }
+    }
+
+    private static String colorIntToHex(int color) {
+        // Strip alpha; calendar provider stores colors as ARGB ints.
+        return String.format(Locale.US, "#%06X", color & 0xFFFFFF);
+    }
+}

--- a/android/app/src/main/java/app/formstr/calendar/DeviceCalendarPlugin.java
+++ b/android/app/src/main/java/app/formstr/calendar/DeviceCalendarPlugin.java
@@ -3,11 +3,8 @@ package app.formstr.calendar;
 import android.Manifest;
 import android.content.ContentResolver;
 import android.content.ContentUris;
-import android.content.Intent;
 import android.database.Cursor;
-import android.net.Uri;
 import android.provider.CalendarContract;
-import android.provider.Settings;
 import android.text.TextUtils;
 import android.util.Log;
 
@@ -107,7 +104,7 @@ public class DeviceCalendarPlugin extends Plugin {
 
                 JSObject obj = new JSObject();
                 obj.put("id", String.valueOf(id));
-                obj.put("name", TextUtils.isEmpty(name) ? "(Unnamed)" : name);
+                obj.put("name", TextUtils.isEmpty(name) ? "" : name);
                 obj.put("accountName", accountName == null ? "" : accountName);
                 obj.put("color", colorIntToHex(color));
                 obj.put("isPrimary", isPrimary);
@@ -228,25 +225,6 @@ public class DeviceCalendarPlugin extends Plugin {
         JSObject result = new JSObject();
         result.put("events", events);
         call.resolve(result);
-    }
-
-    /**
-     * Opens the app's system settings page so the user can flip calendar
-     * permission back on after Android has stopped surfacing the runtime
-     * dialog (repeated denial / "don't ask again").
-     */
-    @PluginMethod
-    public void openAppSettings(PluginCall call) {
-        try {
-            Intent intent = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
-            intent.setData(Uri.fromParts("package", getContext().getPackageName(), null));
-            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-            getContext().startActivity(intent);
-            call.resolve();
-        } catch (Exception e) {
-            Log.e(TAG, "openAppSettings failed", e);
-            call.reject("Failed to open app settings: " + e.getMessage());
-        }
     }
 
     private PermissionState currentPermissionState() {

--- a/android/app/src/main/java/app/formstr/calendar/MainActivity.java
+++ b/android/app/src/main/java/app/formstr/calendar/MainActivity.java
@@ -31,6 +31,7 @@ public class MainActivity extends BridgeActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         registerPlugin(AppReadyPlugin.class);
+        registerPlugin(DeviceCalendarPlugin.class);
         super.onCreate(savedInstanceState);
 
         View contentView = findViewById(android.R.id.content);

--- a/src/common/dictionary.ts
+++ b/src/common/dictionary.ts
@@ -113,6 +113,11 @@ const dictionary: NestedObject = {
       copyLink: "Copy link to this event",
       openNewTab: "Open event in new tab",
       downloadDetails: "Download event details",
+      untitled: "Untitled",
+      allDayLabel: "All day",
+      allDayDate: "{date} ⋅ {label}",
+      allDayDateRange: "{start} – {end} ⋅ {label}",
+      deviceReadOnly: "From your device calendar — read-only.",
       repeats: "Repeats {label}",
       event: "Event",
       eventNotFound: "Event not found. It may not have loaded yet.",
@@ -158,6 +163,30 @@ const dictionary: NestedObject = {
       calendars: "Calendars",
       noCalendarsYet: "No calendars yet",
       createCalendar: "Create Calendar",
+    },
+    deviceCalendar: {
+      title: "Device calendars",
+      visibleCount: "{visibleCount}/{calendarCount} visible",
+      refresh: "Refresh device calendars",
+      connectHelp:
+        "Show events from your phone's calendar apps alongside Nostr events.",
+      connect: "Connect device calendars",
+      empty: "No calendars found on this device.",
+      showAll: "Show all",
+      hideAll: "Hide all",
+      localDevice: "Local device",
+      unnamed: "Unnamed calendar",
+      errorPermissionDenied: "Calendar permission is not currently granted.",
+      errorInvalidCalendarIds:
+        "We could not read those device calendars. Please refresh and try again.",
+      errorInvalidRange:
+        "We could not load device events for that date range. Please try again.",
+      errorReadCalendars:
+        "We could not read your device calendars. Please try again.",
+      errorReadEvents:
+        "We could not load events from your device calendars. Please try again.",
+      errorUnknown:
+        "Something went wrong while reading your device calendars. Please try again.",
     },
     addToCalendar: {
       addToCalendar: "Add to Calendar",
@@ -422,6 +451,11 @@ const dictionary: NestedObject = {
       copyLink: "Link zu diesem Termin kopieren",
       openNewTab: "Termin in neuem Tab öffnen",
       downloadDetails: "Termindetails herunterladen",
+      untitled: "Ohne Titel",
+      allDayLabel: "Ganztägig",
+      allDayDate: "{date} ⋅ {label}",
+      allDayDateRange: "{start} – {end} ⋅ {label}",
+      deviceReadOnly: "Aus dem Gerätekalender — schreibgeschützt.",
       repeats: "Wiederholt sich {label}",
       event: "Termin",
       eventNotFound:
@@ -468,6 +502,31 @@ const dictionary: NestedObject = {
       calendars: "Kalender",
       noCalendarsYet: "Noch keine Kalender",
       createCalendar: "Kalender erstellen",
+    },
+    deviceCalendar: {
+      title: "Gerätekalender",
+      visibleCount: "{visibleCount}/{calendarCount} sichtbar",
+      refresh: "Gerätekalender aktualisieren",
+      connectHelp:
+        "Zeigt Ereignisse aus den Kalender-Apps Ihres Telefons neben\nNostr-Terminen an.",
+      connect: "Gerätekalender verbinden",
+      empty: "Auf diesem Gerät wurden keine Kalender gefunden.",
+      showAll: "Alle anzeigen",
+      hideAll: "Alle ausblenden",
+      localDevice: "Lokales Gerät",
+      unnamed: "Unbenannter Kalender",
+      errorPermissionDenied:
+        "Die Kalenderberechtigung ist derzeit nicht erteilt.",
+      errorInvalidCalendarIds:
+        "Diese Gerätekalender konnten nicht gelesen werden. Bitte aktualisieren Sie und versuchen Sie es erneut.",
+      errorInvalidRange:
+        "Geräteereignisse für diesen Datumsbereich konnten nicht geladen werden. Bitte versuchen Sie es erneut.",
+      errorReadCalendars:
+        "Ihre Gerätekalender konnten nicht gelesen werden. Bitte versuchen Sie es erneut.",
+      errorReadEvents:
+        "Ereignisse aus Ihren Gerätekalendern konnten nicht geladen werden. Bitte versuchen Sie es erneut.",
+      errorUnknown:
+        "Beim Lesen Ihrer Gerätekalender ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut.",
     },
     addToCalendar: {
       addToCalendar: "Zum Kalender hinzufügen",
@@ -619,7 +678,8 @@ const dictionary: NestedObject = {
       customDurationPlaceholder: "z.B. 45",
       openLink: "Link öffnen",
       copyLink: "Link kopieren",
-      noBlockedDates: "Keine gesperrten Tage. Fügen Sie Tage hinzu, um sie für Buchungen zu sperren.",
+      noBlockedDates:
+        "Keine gesperrten Tage. Fügen Sie Tage hinzu, um sie für Buchungen zu sperren.",
     },
   },
 };

--- a/src/components/AddToCalendarDialog.tsx
+++ b/src/components/AddToCalendarDialog.tsx
@@ -76,6 +76,7 @@ export function AddToCalendarDialog({
               begin={event.begin}
               end={event.end}
               repeat={event.repeat}
+              allDay={event.allDay}
             />
           </Box>
 

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -2,115 +2,28 @@ import { useTimeBasedEvents } from "../stores/events";
 import { DayView } from "./DayView";
 import { MonthView } from "./MonthView";
 import { WeekView } from "./WeekView";
-import { useLayout, type Layout } from "../hooks/useLayout";
+import { useLayout } from "../hooks/useLayout";
 import { CalendarHeader } from "./CalendarHeader";
 import { Box } from "@mui/material";
 import { SwipeableView } from "./SwipeableView";
 import { useCalendarLists } from "../stores/calendarLists";
 import { useInvitations } from "../stores/invitations";
-import { useDeviceCalendars } from "../stores/deviceCalendars";
-import { useEffect } from "react";
-import { DeviceCalendar } from "../plugins/deviceCalendar";
 import { useDateWithRouting } from "../hooks/useDateWithRouting";
-import type { Dayjs } from "dayjs";
-import { deviceCalendarIdFor } from "../utils/deviceCalendarAdapter";
-
-function getDeviceEventRange(date: Dayjs, layout: Layout) {
-  let rangeStart = date.startOf("day");
-  let rangeEnd = date.endOf("day");
-
-  if (layout === "week") {
-    rangeStart = date.startOf("week").startOf("day");
-    rangeEnd = date.endOf("week").endOf("day");
-  } else if (layout === "month") {
-    rangeStart = date.startOf("month").startOf("week").startOf("day");
-    rangeEnd = date.endOf("month").endOf("week").endOf("day");
-  }
-
-  return {
-    // Pad by a day on each side so spanning all-day and overnight events are
-    // present when the visible range clips them at the boundary.
-    startMs: rangeStart.subtract(1, "day").valueOf(),
-    endMs: rangeEnd.add(1, "day").valueOf(),
-  };
-}
+import { useVisibleDeviceEvents } from "../hooks/useVisibleDeviceEvents";
 
 function Calendar() {
   const events = useTimeBasedEvents((state) => state);
   const calendars = useCalendarLists((state) => state.calendars);
-  const {invitations} = useInvitations();
-
-
+  const { invitations } = useInvitations();
   const { layout } = useLayout();
   const { date } = useDateWithRouting();
-  const deviceInit = useDeviceCalendars((s) => s.init);
-  const deviceSyncPermission = useDeviceCalendars((s) => s.syncPermission);
-  const deviceRefreshEvents = useDeviceCalendars((s) => s.refreshEvents);
-  const devicePermission = useDeviceCalendars((s) => s.permission);
-  const deviceCalendarsList = useDeviceCalendars((s) => s.calendars);
-  const deviceVisibility = useDeviceCalendars((s) => s.visibility);
-  const deviceEvents = useDeviceCalendars((s) => s.events);
-
-  useEffect(() => {
-    deviceInit();
-  }, [deviceInit]);
-
-  useEffect(() => {
-    if (!DeviceCalendar.isAvailable()) {
-      return;
-    }
-
-    let cancelled = false;
-    let removeResume: (() => Promise<void>) | undefined;
-
-    void (async () => {
-      try {
-        const { App: CapacitorApp } = await import("@capacitor/app");
-        const listener = await CapacitorApp.addListener("resume", () => {
-          void deviceSyncPermission();
-        });
-        if (cancelled) {
-          void listener.remove();
-          return;
-        }
-        removeResume = () => listener.remove();
-      } catch {
-        // Ignore on platforms where lifecycle events are unavailable.
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-      void removeResume?.();
-    };
-  }, [deviceSyncPermission]);
-
-  useEffect(() => {
-    if (devicePermission !== "granted") return;
-    deviceRefreshEvents(getDeviceEventRange(date, layout));
-  }, [
-    devicePermission,
-    date,
-    layout,
-    deviceCalendarsList,
-    deviceVisibility,
-    deviceRefreshEvents,
-  ]);
+  const visibleDeviceEvents = useVisibleDeviceEvents(date, layout);
 
   const visibleCalendars = new Set(
     calendars.filter((cal) => cal.isVisible).map((cal) => cal.id),
   );
   const visibleEvents = events.events.filter((evt) =>
     visibleCalendars.has(evt.calendarId ?? ""),
-  );
-
-  const visibleDeviceCalendarIds = new Set(
-    deviceCalendarsList
-      .filter((calendar) => deviceVisibility[calendar.id] !== false)
-      .map((calendar) => deviceCalendarIdFor(calendar.id)),
-  );
-  const visibleDeviceEvents = deviceEvents.filter((event) =>
-    visibleDeviceCalendarIds.has(event.calendarId ?? ""),
   );
 
   const allEvents = [

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -2,28 +2,119 @@ import { useTimeBasedEvents } from "../stores/events";
 import { DayView } from "./DayView";
 import { MonthView } from "./MonthView";
 import { WeekView } from "./WeekView";
-import { useLayout } from "../hooks/useLayout";
+import { useLayout, type Layout } from "../hooks/useLayout";
 import { CalendarHeader } from "./CalendarHeader";
 import { Box } from "@mui/material";
 import { SwipeableView } from "./SwipeableView";
 import { useCalendarLists } from "../stores/calendarLists";
 import { useInvitations } from "../stores/invitations";
+import { useDeviceCalendars } from "../stores/deviceCalendars";
+import { useEffect } from "react";
+import { DeviceCalendar } from "../plugins/deviceCalendar";
+import { useDateWithRouting } from "../hooks/useDateWithRouting";
+import type { Dayjs } from "dayjs";
+import { deviceCalendarIdFor } from "../utils/deviceCalendarAdapter";
+
+function getDeviceEventRange(date: Dayjs, layout: Layout) {
+  let rangeStart = date.startOf("day");
+  let rangeEnd = date.endOf("day");
+
+  if (layout === "week") {
+    rangeStart = date.startOf("week").startOf("day");
+    rangeEnd = date.endOf("week").endOf("day");
+  } else if (layout === "month") {
+    rangeStart = date.startOf("month").startOf("week").startOf("day");
+    rangeEnd = date.endOf("month").endOf("week").endOf("day");
+  }
+
+  return {
+    // Pad by a day on each side so spanning all-day and overnight events are
+    // present when the visible range clips them at the boundary.
+    startMs: rangeStart.subtract(1, "day").valueOf(),
+    endMs: rangeEnd.add(1, "day").valueOf(),
+  };
+}
 
 function Calendar() {
   const events = useTimeBasedEvents((state) => state);
   const calendars = useCalendarLists((state) => state.calendars);
   const { invitations } = useInvitations();
   const { layout } = useLayout();
-  const visibileCalendars = new Set(
+  const { date } = useDateWithRouting();
+  const deviceInit = useDeviceCalendars((s) => s.init);
+  const deviceSyncPermission = useDeviceCalendars((s) => s.syncPermission);
+  const deviceRefreshEvents = useDeviceCalendars((s) => s.refreshEvents);
+  const devicePermission = useDeviceCalendars((s) => s.permission);
+  const deviceCalendarsList = useDeviceCalendars((s) => s.calendars);
+  const deviceVisibility = useDeviceCalendars((s) => s.visibility);
+  const deviceEvents = useDeviceCalendars((s) => s.events);
+
+  useEffect(() => {
+    deviceInit();
+  }, [deviceInit]);
+
+  useEffect(() => {
+    if (!DeviceCalendar.isAvailable()) {
+      return;
+    }
+
+    let cancelled = false;
+    let removeResume: (() => Promise<void>) | undefined;
+
+    void (async () => {
+      try {
+        const { App: CapacitorApp } = await import("@capacitor/app");
+        const listener = await CapacitorApp.addListener("resume", () => {
+          void deviceSyncPermission();
+        });
+        if (cancelled) {
+          void listener.remove();
+          return;
+        }
+        removeResume = () => listener.remove();
+      } catch {
+        // Ignore on platforms where lifecycle events are unavailable.
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      void removeResume?.();
+    };
+  }, [deviceSyncPermission]);
+
+  useEffect(() => {
+    if (devicePermission !== "granted") return;
+    deviceRefreshEvents(getDeviceEventRange(date, layout));
+  }, [
+    devicePermission,
+    date,
+    layout,
+    deviceCalendarsList,
+    deviceVisibility,
+    deviceRefreshEvents,
+  ]);
+
+  const visibleCalendars = new Set(
     calendars.filter((cal) => cal.isVisible).map((cal) => cal.id),
   );
   const visibleEvents = events.events.filter((evt) =>
-    visibileCalendars.has(evt.calendarId ?? ""),
+    visibleCalendars.has(evt.calendarId ?? ""),
+  );
+
+  const visibleDeviceCalendarIds = new Set(
+    deviceCalendarsList
+      .filter((calendar) => deviceVisibility[calendar.id] !== false)
+      .map((calendar) => deviceCalendarIdFor(calendar.id)),
+  );
+  const visibleDeviceEvents = deviceEvents.filter((event) =>
+    visibleDeviceCalendarIds.has(event.calendarId ?? ""),
   );
 
   const allEvents = [
     ...visibleEvents,
     ...invitations.filter((inv) => inv.event).map((inv) => inv.event!),
+    ...visibleDeviceEvents,
   ];
   return (
     <Box p={2}>

--- a/src/components/CalendarEvent.tsx
+++ b/src/components/CalendarEvent.tsx
@@ -42,7 +42,11 @@ import PhoneAndroidIcon from "@mui/icons-material/PhoneAndroid";
 import dayjs from "dayjs";
 import { exportICS, isMobile } from "../common/utils";
 import { encodeNAddr } from "../common/nostr";
-import { getDuplicateEventPage, getEditEventPage, getEventPage } from "../utils/routingHelper";
+import {
+  getDuplicateEventPage,
+  getEditEventPage,
+  getEventPage,
+} from "../utils/routingHelper";
 import { useNavigate } from "react-router";
 import { getAppBaseUrl, isNative } from "../utils/platform";
 import { useNotifications } from "../stores/notifications";
@@ -53,7 +57,7 @@ import {
   DEVICE_CALENDAR_ID_PREFIX,
   deviceCalendarColor,
 } from "../utils/deviceCalendarAdapter";
-import { FormattedMessage, useIntl } from "react-intl";
+import { FormattedMessage, useIntl, type IntlShape } from "react-intl";
 import { useUser } from "../stores/user";
 import { DeleteEventDialog } from "./DeleteEventDialog";
 import { CalendarListSelect } from "./CalendarListSelect";
@@ -131,11 +135,12 @@ function getColorScheme(
     };
   }
 
-  // Device-sourced events get a muted, calendar-coloured style.
+  // Device-sourced events use the full calendar color so they carry the same
+  // visual weight as other calendars.
   if (event.source === "device" && calendarColor) {
     return {
       color: "#fff",
-      backgroundColor: alpha(calendarColor, 0.6),
+      backgroundColor: calendarColor,
       border: `1px solid ${alpha(calendarColor, 0.9)}`,
     };
   }
@@ -161,6 +166,26 @@ function getColorScheme(
   };
 }
 
+function getEventDisplayTitle(
+  event: ICalendarEvent,
+  intl: IntlShape,
+  maxDescLength = 20,
+): string {
+  const title = event.title?.trim();
+  if (title) {
+    return title;
+  }
+
+  const description = event.description?.trim() ?? "";
+  if (description) {
+    return description.length > maxDescLength
+      ? `${description.substring(0, maxDescLength)}...`
+      : description;
+  }
+
+  return intl.formatMessage({ id: "event.untitled" });
+}
+
 export function CalendarEventCard({
   event,
   offset = "0px",
@@ -168,17 +193,13 @@ export function CalendarEventCard({
   // const { attributes, listeners, setNodeRef } = useDraggable({ id: event.id });
   const [open, setOpen] = useState(false);
   const handleClose = () => setOpen(false);
-  const maxDescLength = 20;
+  const intl = useIntl();
   const theme = useTheme();
 
   const resolvedColor = useResolvedCalendarColor(event);
 
   const colorScheme = getColorScheme(event, theme, resolvedColor);
-  const title =
-    event.title ??
-    (event.description.length > maxDescLength
-      ? `${event.description.substring(0, maxDescLength)}...`
-      : event.description);
+  const title = getEventDisplayTitle(event, intl);
   return (
     <>
       <Paper
@@ -230,14 +251,10 @@ export function CalendarEventView({
   open = false,
   onClose,
 }: CalendarEventViewProps) {
+  const intl = useIntl();
   const theme = useTheme();
   const fullScreen = useMediaQuery(theme.breakpoints.down("sm"));
-  const maxDescLength = 20;
-  const title =
-    event.title ??
-    (event.description.length > maxDescLength
-      ? `${event.description.substring(0, maxDescLength)}...`
-      : event.description);
+  const title = getEventDisplayTitle(event, intl);
 
   const handleClose = () => onClose?.();
 
@@ -610,7 +627,7 @@ export function CalendarEvent({ event }: CalendarEventViewProps) {
             <>
               <Divider />
               <Typography variant="caption" color="text.secondary">
-                From your device calendar — read-only.
+                {intl.formatMessage({ id: "event.deviceReadOnly" })}
               </Typography>
             </>
           ) : (
@@ -942,6 +959,7 @@ function InvitationAcceptBar({ event }: { event: ICalendarEvent }) {
 /** Compact pill used in the all-day banner row of Day and Week views. */
 export function AllDayEventChip({ event }: { event: ICalendarEvent }) {
   const [open, setOpen] = useState(false);
+  const intl = useIntl();
   const theme = useTheme();
 
   const resolvedColor = useResolvedCalendarColor(event);
@@ -972,7 +990,7 @@ export function AllDayEventChip({ event }: { event: ICalendarEvent }) {
               sx={{ fontSize: 12, mr: 0.5, verticalAlign: "middle" }}
             />
           )}
-          {event.title}
+          {getEventDisplayTitle(event, intl)}
         </Typography>
       </Box>
       <CalendarEventView

--- a/src/components/CalendarEvent.tsx
+++ b/src/components/CalendarEvent.tsx
@@ -406,8 +406,6 @@ function ActionButtons({
     navigate(duplicateLink);
   };
 
-  const iconSize = isMobile ? "small" : "medium";
-
   return (
     <Box
       minWidth={isMobile ? "inherit" : "160px"}

--- a/src/components/CalendarEvent.tsx
+++ b/src/components/CalendarEvent.tsx
@@ -525,6 +525,7 @@ export function CalendarEvent({ event }: CalendarEventViewProps) {
             begin={event.begin}
             end={event.end}
             repeat={event.repeat}
+            allDay={event.allDay}
           ></TimeRenderer>
 
           {event.description && (

--- a/src/components/CalendarEvent.tsx
+++ b/src/components/CalendarEvent.tsx
@@ -35,6 +35,7 @@ import Download from "@mui/icons-material/Download";
 import Edit from "@mui/icons-material/Edit";
 import Delete from "@mui/icons-material/Delete";
 import NotificationsActiveIcon from "@mui/icons-material/NotificationsActive";
+import PhoneAndroidIcon from "@mui/icons-material/PhoneAndroid";
 import dayjs from "dayjs";
 import { exportICS, isMobile } from "../common/utils";
 import { encodeNAddr } from "../common/nostr";
@@ -44,10 +45,16 @@ import { getAppBaseUrl, isNative } from "../utils/platform";
 import { useNotifications } from "../stores/notifications";
 import { useCalendarLists } from "../stores/calendarLists";
 import { useTimeBasedEvents } from "../stores/events";
+import { useDeviceCalendars } from "../stores/deviceCalendars";
+import {
+  DEVICE_CALENDAR_ID_PREFIX,
+  deviceCalendarColor,
+} from "../utils/deviceCalendarAdapter";
 import { FormattedMessage, useIntl } from "react-intl";
 import { useUser } from "../stores/user";
 import { DeleteEventDialog } from "./DeleteEventDialog";
 import { CalendarListSelect } from "./CalendarListSelect";
+
 import { useInvitations } from "../stores/invitations";
 import {
   buildEventRef,
@@ -71,6 +78,31 @@ export interface CalendarEventViewProps {
 }
 
 /**
+ * Resolves the display color for an event by checking, in order:
+ * 1. The owning Nostr calendar list's color, if `event.calendarId` matches one
+ * 2. The device calendar's hex color when `event.source === "device"`
+ * 3. `undefined` (caller falls back to the theme palette)
+ */
+function useResolvedCalendarColor(event: ICalendarEvent): string | undefined {
+  const nostrCalendars = useCalendarLists.getState().calendars;
+  const deviceCalendars = useDeviceCalendars((s) => s.calendars);
+
+  const owning = event.calendarId
+    ? nostrCalendars.find((c) => c.id === event.calendarId)
+    : undefined;
+  if (owning?.color) return owning.color;
+
+  if (event.source === "device" && event.calendarId) {
+    const nativeId = event.calendarId.startsWith(DEVICE_CALENDAR_ID_PREFIX)
+      ? event.calendarId.slice(DEVICE_CALENDAR_ID_PREFIX.length)
+      : event.calendarId;
+    const info = deviceCalendars.find((c) => c.id === nativeId);
+    if (info) return deviceCalendarColor(info);
+  }
+  return undefined;
+}
+
+/**
  * Returns color scheme for an event card based on its type:
  * - Invitation events: grey background with dashed border
  * - Private events with a calendar: themed by the calendar's color
@@ -88,6 +120,15 @@ function getColorScheme(
       color: theme.palette.text.secondary,
       backgroundColor: "#e0e0e0",
       border: "2px dashed #999",
+    };
+  }
+
+  // Device-sourced events get a muted, calendar-coloured style.
+  if (event.source === "device" && calendarColor) {
+    return {
+      color: "#fff",
+      backgroundColor: alpha(calendarColor, 0.6),
+      border: `1px solid ${alpha(calendarColor, 0.9)}`,
     };
   }
 
@@ -122,12 +163,9 @@ export function CalendarEventCard({
   const maxDescLength = 20;
   const theme = useTheme();
 
-  // Look up the calendar for this event
-  const calendars = useCalendarLists.getState().calendars;
-  const calendar = event.calendarId
-    ? calendars.find((c) => c.id === event.calendarId)
-    : undefined;
-  const colorScheme = getColorScheme(event, theme, calendar?.color);
+  const resolvedColor = useResolvedCalendarColor(event);
+
+  const colorScheme = getColorScheme(event, theme, resolvedColor);
   const title =
     event.title ??
     (event.description.length > maxDescLength
@@ -160,6 +198,11 @@ export function CalendarEventCard({
           color={colorScheme.color}
           fontWeight={600}
         >
+          {event.source === "device" && (
+            <PhoneAndroidIcon
+              sx={{ fontSize: 12, mr: 0.5, verticalAlign: "middle" }}
+            />
+          )}
           {title}
         </Typography>
       </Paper>
@@ -271,6 +314,41 @@ function ActionButtons({
   showOpenInNew?: boolean;
 }) {
   const intl = useIntl();
+  const { user } = useUser();
+  const navigate = useNavigate();
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const iconSize = isMobile ? "small" : "medium";
+
+  // Device events have no Nostr coordinate; render a slim action bar that
+  // only allows ICS export + close. No edit, delete, copy-link, or share.
+  if (event.source === "device") {
+    return (
+      <Box
+        minWidth={isMobile ? "inherit" : "80px"}
+        sx={{ whiteSpace: "nowrap" }}
+      >
+        {!isNative && (
+          <IconButton size={iconSize} onClick={() => exportICS(event)}>
+            <Tooltip
+              title={intl.formatMessage({ id: "event.downloadDetails" })}
+            >
+              <Download fontSize={iconSize} />
+            </Tooltip>
+          </IconButton>
+        )}
+        {showClose && (
+          <IconButton
+            size={iconSize}
+            aria-label={intl.formatMessage({ id: "navigation.close" })}
+            onClick={closeModal}
+          >
+            <CloseIcon fontSize={iconSize} />
+          </IconButton>
+        )}
+      </Box>
+    );
+  }
+
   const linkToEvent = getEventPage(
     encodeNAddr(
       {
@@ -286,10 +364,7 @@ function ActionButtons({
   const copyLinkToEvent = () => {
     navigator.clipboard.writeText(eventUrl);
   };
-  const { user } = useUser();
-  const navigate = useNavigate();
   const isEditable = event.user === user?.pubkey;
-  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 
   const editEvent = () => {
     const editLink = getEditEventPage(
@@ -306,8 +381,6 @@ function ActionButtons({
     closeModal();
     navigate(editLink);
   };
-
-  const iconSize = isMobile ? "small" : "medium";
 
   return (
     <Box
@@ -378,7 +451,10 @@ export function CalendarEvent({ event }: CalendarEventViewProps) {
   const locations = event.location.filter((location) => !!location?.trim?.());
   const { calendars, moveEventToCalendar } = useCalendarLists();
   const { updateEvent } = useTimeBasedEvents();
-  const eventCoordinate = getCalendarEventCoordinate(event);
+  const isDeviceEvent = event.source === "device";
+  const eventCoordinate = isDeviceEvent
+    ? ""
+    : getCalendarEventCoordinate(event);
 
   const calendar = event.calendarId
     ? calendars.find((c) => c.id === event.calendarId)
@@ -498,6 +574,13 @@ export function CalendarEvent({ event }: CalendarEventViewProps) {
                 onCalendarUpdate={handleCalendarUpdate}
               />
             </>
+          ) : isDeviceEvent ? (
+            <>
+              <Divider />
+              <Typography variant="caption" color="text.secondary">
+                From your device calendar — read-only.
+              </Typography>
+            </>
           ) : (
             <>
               <Divider />
@@ -505,7 +588,9 @@ export function CalendarEvent({ event }: CalendarEventViewProps) {
             </>
           )}
 
-          <ScheduledNotificationsSection eventId={event.id} />
+          {!isDeviceEvent && (
+            <ScheduledNotificationsSection eventId={event.id} />
+          )}
         </Stack>
       </Box>
     </Box>
@@ -793,6 +878,52 @@ function InvitationAcceptBar({ event }: { event: ICalendarEvent }) {
           </Button>
         </DialogActions>
       </Dialog>
+    </>
+  );
+}
+
+/** Compact pill used in the all-day banner row of Day and Week views. */
+export function AllDayEventChip({ event }: { event: ICalendarEvent }) {
+  const [open, setOpen] = useState(false);
+  const theme = useTheme();
+
+  const resolvedColor = useResolvedCalendarColor(event);
+  const colorScheme = getColorScheme(event, theme, resolvedColor);
+
+  return (
+    <>
+      <Box
+        onClick={() => setOpen(true)}
+        sx={{
+          bgcolor: colorScheme.backgroundColor,
+          border: colorScheme.border,
+          borderRadius: 0.5,
+          px: 0.5,
+          mb: 0.25,
+          cursor: "pointer",
+          overflow: "hidden",
+          whiteSpace: "nowrap",
+          textOverflow: "ellipsis",
+        }}
+      >
+        <Typography
+          variant="caption"
+          sx={{ color: colorScheme.color, fontWeight: 600 }}
+        >
+          {event.source === "device" && (
+            <PhoneAndroidIcon
+              sx={{ fontSize: 12, mr: 0.5, verticalAlign: "middle" }}
+            />
+          )}
+          {event.title}
+        </Typography>
+      </Box>
+      <CalendarEventView
+        event={event}
+        display="modal"
+        open={open}
+        onClose={() => setOpen(false)}
+      />
     </>
   );
 }

--- a/src/components/CalendarSidebar.tsx
+++ b/src/components/CalendarSidebar.tsx
@@ -241,6 +241,7 @@ export function CalendarSidebar({ onClose }: CalendarSidebarProps) {
  * where the bridge is unavailable.
  */
 function DeviceCalendarsSection() {
+  const intl = useIntl();
   const available = useDeviceCalendars((s) => s.available);
   const permission = useDeviceCalendars((s) => s.permission);
   const calendars = useDeviceCalendars((s) => s.calendars);
@@ -249,22 +250,23 @@ function DeviceCalendarsSection() {
   const toggleVisibility = useDeviceCalendars((s) => s.toggleVisibility);
   const setAllVisibility = useDeviceCalendars((s) => s.setAllVisibility);
   const refreshCalendars = useDeviceCalendars((s) => s.refreshCalendars);
-  const openAppSettings = useDeviceCalendars((s) => s.openAppSettings);
-  const permanentlyDenied = useDeviceCalendars((s) => s.permanentlyDenied);
   const loading = useDeviceCalendars((s) => s.loading);
   const error = useDeviceCalendars((s) => s.error);
+  const localDeviceLabel = intl.formatMessage({
+    id: "deviceCalendar.localDevice",
+  });
 
   const groupedCalendars = useMemo(() => {
     const groups = new Map<string, typeof calendars>();
     for (const calendar of calendars) {
-      const key = calendar.accountName || "Local device";
+      const key = calendar.accountName || localDeviceLabel;
       if (!groups.has(key)) {
         groups.set(key, []);
       }
       groups.get(key)!.push(calendar);
     }
     return Array.from(groups.entries()).sort(([a], [b]) => a.localeCompare(b));
-  }, [calendars]);
+  }, [calendars, localDeviceLabel]);
 
   const visibleCount = calendars.filter(
     (c) => visibility[c.id] !== false,
@@ -281,12 +283,18 @@ function DeviceCalendarsSection() {
         mb={1}
       >
         <Typography variant="subtitle2" fontWeight={600}>
-          Device calendars
+          {intl.formatMessage({ id: "deviceCalendar.title" })}
         </Typography>
         <Stack direction="row" alignItems="center" spacing={0.5}>
           {permission === "granted" && calendars.length > 0 && (
             <Typography variant="caption" color="text.secondary">
-              {visibleCount}/{calendars.length} visible
+              {intl.formatMessage(
+                { id: "deviceCalendar.visibleCount" },
+                {
+                  visibleCount,
+                  calendarCount: calendars.length,
+                },
+              )}
             </Typography>
           )}
           {permission === "granted" && (
@@ -294,7 +302,7 @@ function DeviceCalendarsSection() {
               size="small"
               onClick={() => void refreshCalendars()}
               disabled={loading}
-              title="Refresh device calendars"
+              title={intl.formatMessage({ id: "deviceCalendar.refresh" })}
             >
               <RefreshIcon
                 fontSize="small"
@@ -313,41 +321,22 @@ function DeviceCalendarsSection() {
 
       {error && (
         <Alert severity="error" sx={{ mb: 1 }} variant="outlined">
-          {error}
+          {intl.formatMessage({ id: error })}
         </Alert>
       )}
 
       {permission !== "granted" ? (
         <Box py={1}>
-          {permanentlyDenied ? (
-            <>
-              <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
-                Calendar permission was denied. Open system settings to grant
-                access, then return here.
-              </Typography>
-              <Button
-                size="small"
-                variant="outlined"
-                onClick={() => void openAppSettings()}
-              >
-                Open settings
-              </Button>
-            </>
-          ) : (
-            <>
-              <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
-                Show events from your phone's calendar apps alongside Nostr
-                events.
-              </Typography>
-              <Button size="small" variant="outlined" onClick={requestAccess}>
-                Connect device calendars
-              </Button>
-            </>
-          )}
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+            {intl.formatMessage({ id: "deviceCalendar.connectHelp" })}
+          </Typography>
+          <Button size="small" variant="outlined" onClick={requestAccess}>
+            {intl.formatMessage({ id: "deviceCalendar.connect" })}
+          </Button>
         </Box>
       ) : calendars.length === 0 ? (
         <Typography variant="body2" color="text.secondary" py={1}>
-          No calendars found on this device.
+          {intl.formatMessage({ id: "deviceCalendar.empty" })}
         </Typography>
       ) : (
         <>
@@ -358,7 +347,7 @@ function DeviceCalendarsSection() {
               disabled={visibleCount === calendars.length}
               onClick={() => setAllVisibility(true)}
             >
-              Show all
+              {intl.formatMessage({ id: "deviceCalendar.showAll" })}
             </Button>
             <Button
               size="small"
@@ -366,7 +355,7 @@ function DeviceCalendarsSection() {
               disabled={visibleCount === 0}
               onClick={() => setAllVisibility(false)}
             >
-              Hide all
+              {intl.formatMessage({ id: "deviceCalendar.hideAll" })}
             </Button>
           </Stack>
 
@@ -438,7 +427,10 @@ function DeviceCalendarsSection() {
                             whiteSpace: "normal",
                           }}
                         >
-                          {c.name}
+                          {c.name.trim() ||
+                            intl.formatMessage({
+                              id: "deviceCalendar.unnamed",
+                            })}
                         </Typography>
                       </Box>
                     </Box>

--- a/src/components/CalendarSidebar.tsx
+++ b/src/components/CalendarSidebar.tsx
@@ -10,13 +10,15 @@
  * Clicking a calendar name opens the management dialog for editing.
  */
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import {
+  Alert,
   Box,
   Checkbox,
   Typography,
   IconButton,
   Button,
+  Stack,
   Tooltip,
   useMediaQuery,
   useTheme,
@@ -25,6 +27,7 @@ import CloseIcon from "@mui/icons-material/Close";
 import AddIcon from "@mui/icons-material/Add";
 import CircleIcon from "@mui/icons-material/Circle";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
+import RefreshIcon from "@mui/icons-material/Refresh";
 import { DatePicker } from "./DatePicker";
 import { useCalendarLists } from "../stores/calendarLists";
 import { CalendarManageDialog } from "./CalendarManageDialog";
@@ -34,6 +37,8 @@ import {
 } from "../utils/calendarListTypes";
 import { useIntl } from "react-intl";
 import { useTimeBasedEvents } from "../stores/events";
+import { useDeviceCalendars } from "../stores/deviceCalendars";
+import { deviceCalendarColor } from "../utils/deviceCalendarAdapter";
 
 interface CalendarSidebarProps {
   onClose: () => void;
@@ -75,8 +80,7 @@ export function CalendarSidebar({ onClose }: CalendarSidebarProps) {
     if (editingCalendar) {
       const preferenceChanged =
         (editingCalendar.notificationPreference ??
-          DEFAULT_NOTIFICATION_PREFERENCE) !==
-        data.notificationPreference;
+          DEFAULT_NOTIFICATION_PREFERENCE) !== data.notificationPreference;
 
       await updateCalendar({ ...editingCalendar, ...data });
       if (preferenceChanged) {
@@ -102,7 +106,16 @@ export function CalendarSidebar({ onClose }: CalendarSidebarProps) {
   };
 
   return (
-    <Box padding={theme.spacing(2)} minWidth={260}>
+    <Box
+      padding={theme.spacing(2)}
+      sx={{
+        width: "100%",
+        maxHeight: "100vh",
+        overflowY: "auto",
+        overflowX: "hidden",
+        boxSizing: "border-box",
+      }}
+    >
       <Box width="100%" justifyContent="end" display="flex">
         {isMobile && (
           <IconButton onClick={onClose}>
@@ -167,11 +180,15 @@ export function CalendarSidebar({ onClose }: CalendarSidebarProps) {
               alignItems="center"
               gap={1}
               flex={1}
+              minWidth={0}
               sx={{ cursor: "pointer", ml: 0.5 }}
               onClick={() => handleEditCalendar(calendar)}
             >
               <CircleIcon sx={{ fontSize: 10, color: calendar.color }} />
-              <Typography variant="body2" noWrap>
+              <Typography
+                variant="body2"
+                sx={{ wordBreak: "break-word", whiteSpace: "normal" }}
+              >
                 {calendar.title}
               </Typography>
             </Box>
@@ -195,6 +212,7 @@ export function CalendarSidebar({ onClose }: CalendarSidebarProps) {
         )}
       </Box>
 
+      <DeviceCalendarsSection />
 
       {manageDialogOpen && (
         <CalendarManageDialog
@@ -204,6 +222,223 @@ export function CalendarSidebar({ onClose }: CalendarSidebarProps) {
           onSave={handleSave}
           onDelete={editingCalendar ? handleDelete : undefined}
         />
+      )}
+    </Box>
+  );
+}
+
+/**
+ * Lists native calendars from the phone (Android only). Hidden on web/iOS
+ * where the bridge is unavailable.
+ */
+function DeviceCalendarsSection() {
+  const available = useDeviceCalendars((s) => s.available);
+  const permission = useDeviceCalendars((s) => s.permission);
+  const calendars = useDeviceCalendars((s) => s.calendars);
+  const visibility = useDeviceCalendars((s) => s.visibility);
+  const requestAccess = useDeviceCalendars((s) => s.requestAccess);
+  const toggleVisibility = useDeviceCalendars((s) => s.toggleVisibility);
+  const setAllVisibility = useDeviceCalendars((s) => s.setAllVisibility);
+  const refreshCalendars = useDeviceCalendars((s) => s.refreshCalendars);
+  const openAppSettings = useDeviceCalendars((s) => s.openAppSettings);
+  const permanentlyDenied = useDeviceCalendars((s) => s.permanentlyDenied);
+  const loading = useDeviceCalendars((s) => s.loading);
+  const error = useDeviceCalendars((s) => s.error);
+
+  const groupedCalendars = useMemo(() => {
+    const groups = new Map<string, typeof calendars>();
+    for (const calendar of calendars) {
+      const key = calendar.accountName || "Local device";
+      if (!groups.has(key)) {
+        groups.set(key, []);
+      }
+      groups.get(key)!.push(calendar);
+    }
+    return Array.from(groups.entries()).sort(([a], [b]) => a.localeCompare(b));
+  }, [calendars]);
+
+  const visibleCount = calendars.filter(
+    (c) => visibility[c.id] !== false,
+  ).length;
+
+  if (!available) return null;
+
+  return (
+    <Box mt={3}>
+      <Stack
+        direction="row"
+        justifyContent="space-between"
+        alignItems="center"
+        mb={1}
+      >
+        <Typography variant="subtitle2" fontWeight={600}>
+          Device calendars
+        </Typography>
+        <Stack direction="row" alignItems="center" spacing={0.5}>
+          {permission === "granted" && calendars.length > 0 && (
+            <Typography variant="caption" color="text.secondary">
+              {visibleCount}/{calendars.length} visible
+            </Typography>
+          )}
+          {permission === "granted" && (
+            <IconButton
+              size="small"
+              onClick={() => void refreshCalendars()}
+              disabled={loading}
+              title="Refresh device calendars"
+            >
+              <RefreshIcon
+                fontSize="small"
+                sx={{
+                  animation: loading ? "spin 1s linear infinite" : undefined,
+                  "@keyframes spin": {
+                    from: { transform: "rotate(0deg)" },
+                    to: { transform: "rotate(360deg)" },
+                  },
+                }}
+              />
+            </IconButton>
+          )}
+        </Stack>
+      </Stack>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 1 }} variant="outlined">
+          {error}
+        </Alert>
+      )}
+
+      {permission !== "granted" ? (
+        <Box py={1}>
+          {permanentlyDenied ? (
+            <>
+              <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                Calendar permission was denied. Open system settings to grant
+                access, then return here.
+              </Typography>
+              <Button
+                size="small"
+                variant="outlined"
+                onClick={() => void openAppSettings()}
+              >
+                Open settings
+              </Button>
+            </>
+          ) : (
+            <>
+              <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                Show events from your phone's calendar apps alongside Nostr
+                events.
+              </Typography>
+              <Button size="small" variant="outlined" onClick={requestAccess}>
+                Connect device calendars
+              </Button>
+            </>
+          )}
+        </Box>
+      ) : calendars.length === 0 ? (
+        <Typography variant="body2" color="text.secondary" py={1}>
+          No calendars found on this device.
+        </Typography>
+      ) : (
+        <>
+          <Stack direction="row" spacing={1} mb={1}>
+            <Button
+              size="small"
+              variant="text"
+              disabled={visibleCount === calendars.length}
+              onClick={() => setAllVisibility(true)}
+            >
+              Show all
+            </Button>
+            <Button
+              size="small"
+              variant="text"
+              disabled={visibleCount === 0}
+              onClick={() => setAllVisibility(false)}
+            >
+              Hide all
+            </Button>
+          </Stack>
+
+          <Box
+            sx={{
+              maxHeight: 260,
+              overflowY: "auto",
+              border: "1px solid",
+              borderColor: "divider",
+              borderRadius: 1,
+              py: 0.5,
+            }}
+          >
+            {groupedCalendars.map(([accountName, accountCalendars]) => (
+              <Box key={accountName}>
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  display="block"
+                  sx={{
+                    px: 1,
+                    pt: 0.5,
+                    wordBreak: "break-all",
+                    whiteSpace: "normal",
+                  }}
+                >
+                  {accountName}
+                </Typography>
+
+                {accountCalendars.map((c) => {
+                  const color = deviceCalendarColor(c);
+                  const visible = visibility[c.id] !== false;
+                  return (
+                    <Box
+                      key={c.id}
+                      display="flex"
+                      alignItems="center"
+                      sx={{
+                        py: 0.5,
+                        "&:hover": { backgroundColor: "action.hover" },
+                        borderRadius: 1,
+                      }}
+                    >
+                      <Checkbox
+                        checked={visible}
+                        onChange={() => toggleVisibility(c.id)}
+                        size="small"
+                        sx={{
+                          color,
+                          "&.Mui-checked": { color },
+                          p: 0.5,
+                        }}
+                      />
+                      <Box
+                        display="flex"
+                        alignItems="center"
+                        gap={1}
+                        flex={1}
+                        ml={0.5}
+                        minWidth={0}
+                      >
+                        <CircleIcon
+                          sx={{ fontSize: 10, color, flexShrink: 0 }}
+                        />
+                        <Typography
+                          variant="body2"
+                          sx={{
+                            wordBreak: "break-word",
+                            whiteSpace: "normal",
+                          }}
+                        >
+                          {c.name}
+                        </Typography>
+                      </Box>
+                    </Box>
+                  );
+                })}
+              </Box>
+            ))}
+          </Box>
+        </>
       )}
     </Box>
   );

--- a/src/components/DayView.tsx
+++ b/src/components/DayView.tsx
@@ -14,12 +14,14 @@ import { TimeMarker } from "./TimeMarker";
 import { useRef, useState } from "react";
 import CalendarEventEdit from "./CalendarEventEdit";
 import { ViewProps } from "./SwipeableView";
+import { useIntl } from "react-intl";
 
 dayjs.extend(weekday);
 dayjs.extend(isSameOrBefore);
 dayjs.extend(isSameOrAfter);
 
 export function DayView({ events, date }: ViewProps) {
+  const intl = useIntl();
   const dayStart = date.startOf("day").valueOf();
   const dayEnd = dayStart + 24 * 60 * 60 * 1000;
   const allDayEvents = events.filter(
@@ -55,7 +57,7 @@ export function DayView({ events, date }: ViewProps) {
             justifyContent="center"
           >
             <Typography variant="caption" sx={{ color: "text.secondary" }}>
-              all-day
+              {intl.formatMessage({ id: "event.allDayLabel" })}
             </Typography>
           </Box>
           <Box flex={1} p={0.5}>

--- a/src/components/DayView.tsx
+++ b/src/components/DayView.tsx
@@ -8,7 +8,7 @@ import {
   getTimeFromCell,
   layoutDayEvents,
 } from "../common/calendarEngine";
-import { CalendarEventCard } from "./CalendarEvent";
+import { AllDayEventChip, CalendarEventCard } from "./CalendarEvent";
 import { DndContext } from "@dnd-kit/core";
 import { TimeMarker } from "./TimeMarker";
 import { useRef, useState } from "react";
@@ -21,7 +21,14 @@ dayjs.extend(isSameOrAfter);
 
 export function DayView({ events, date }: ViewProps) {
   const dayStart = date.startOf("day").valueOf();
-  const dayEvents = layoutDayEvents(getEventSegmentsForDay(events, dayStart));
+  const dayEnd = dayStart + 24 * 60 * 60 * 1000;
+  const allDayEvents = events.filter(
+    (e) => e.allDay && e.begin < dayEnd && e.end > dayStart,
+  );
+  const timedEvents = events.filter((e) => !e.allDay);
+  const dayEvents = layoutDayEvents(
+    getEventSegmentsForDay(timedEvents, dayStart),
+  );
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [clickedDateTime, setClickedDateTime] = useState<number | undefined>();
@@ -35,6 +42,29 @@ export function DayView({ events, date }: ViewProps) {
 
   return (
     <>
+      {allDayEvents.length > 0 && (
+        <Box
+          display="flex"
+          sx={{ borderBottom: "1px solid #ddd", minHeight: 24 }}
+        >
+          <Box
+            width={60}
+            borderRight="1px solid #ddd"
+            display="flex"
+            alignItems="center"
+            justifyContent="center"
+          >
+            <Typography variant="caption" sx={{ color: "text.secondary" }}>
+              all-day
+            </Typography>
+          </Box>
+          <Box flex={1} p={0.5}>
+            {allDayEvents.map((evt) => (
+              <AllDayEventChip key={`${evt.id}:${evt.begin}`} event={evt} />
+            ))}
+          </Box>
+        </Box>
+      )}
       <DndContext>
         <Box display="flex" height={24 * 60}>
           {/* Time column */}

--- a/src/components/DeleteEventDialog.tsx
+++ b/src/components/DeleteEventDialog.tsx
@@ -161,6 +161,7 @@ export function DeleteEventDialog({
               begin={event.begin}
               end={event.end}
               repeat={event.repeat}
+              allDay={event.allDay}
             />
           </Box>
 

--- a/src/components/DeleteEventDialog.tsx
+++ b/src/components/DeleteEventDialog.tsx
@@ -64,6 +64,12 @@ export function DeleteEventDialog({
   const [selectedOption, setSelectedOption] =
     useState<DeleteOption>(getDefaultOption);
 
+  // Defensive: device events have no Nostr identity and must never be deleted
+  // through Nostr. The UI hides the entry point, but bail here as well.
+  if (event.source === "device") {
+    return null;
+  }
+
   const findEventRef = (): string[] | null => {
     if (!event.calendarId) return null;
     const calendar = calendars.find((c) => c.id === event.calendarId);

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -75,7 +75,11 @@ export const Header = ({ onImportEvent }: HeaderProps) => {
           </Stack>
         </Toolbar>
       </AppBar>
-      <Drawer open={drawerOpen} onClose={closeDrawer}>
+      <Drawer
+        open={drawerOpen}
+        onClose={closeDrawer}
+        PaperProps={{ sx: { width: { xs: "100vw", sm: 340 } } }}
+      >
         <CalendarSidebar onClose={closeDrawer} />
       </Drawer>
     </>

--- a/src/components/InvitationPanel.tsx
+++ b/src/components/InvitationPanel.tsx
@@ -106,6 +106,7 @@ export function InvitationPanel() {
                 begin={invitation.event.begin}
                 end={invitation.event.end}
                 repeat={invitation.event.repeat}
+                allDay={invitation.event.allDay}
               />
               {invitation.event.description && (
                 <Typography

--- a/src/components/TimeRenderer.tsx
+++ b/src/components/TimeRenderer.tsx
@@ -31,18 +31,33 @@ export const TimeRenderer = ({
   begin,
   end,
   repeat,
+  allDay,
 }: {
   begin: number;
   end: number;
   repeat: ICalendarEvent["repeat"];
+  allDay?: boolean;
 }) => {
+  // For all-day events, `end` is the exclusive midnight of the day after the
+  // last full day, so subtract 1ms before formatting to get the inclusive
+  // "last day" label users expect.
+  const lastDay = dayjs(end - 1);
+  const isMultiDay = allDay && !lastDay.isSame(dayjs(begin), "day");
+
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: "8px" }}>
       <Box sx={{ display: "flex", alignItems: "center", gap: "8px" }}>
         <AccessTimeIcon />
         <Typography>
-          {dayjs(begin).format("ddd, DD MMMM YYYY ⋅ HH:mm -")}{" "}
-          {dayjs(end).format("HH:mm")}
+          {allDay
+            ? isMultiDay
+              ? `${dayjs(begin).format("ddd, DD MMM")} – ${lastDay.format(
+                  "ddd, DD MMM YYYY",
+                )} ⋅ All day`
+              : `${dayjs(begin).format("ddd, DD MMMM YYYY")} ⋅ All day`
+            : `${dayjs(begin).format(
+                "ddd, DD MMMM YYYY ⋅ HH:mm -",
+              )} ${dayjs(end).format("HH:mm")}`}
         </Typography>
       </Box>
       <Box sx={{ display: "flex", alignItems: "center", gap: "8px" }}>

--- a/src/components/TimeRenderer.tsx
+++ b/src/components/TimeRenderer.tsx
@@ -38,11 +38,13 @@ export const TimeRenderer = ({
   repeat: ICalendarEvent["repeat"];
   allDay?: boolean;
 }) => {
+  const intl = useIntl();
   // For all-day events, `end` is the exclusive midnight of the day after the
   // last full day, so subtract 1ms before formatting to get the inclusive
   // "last day" label users expect.
   const lastDay = dayjs(end - 1);
   const isMultiDay = allDay && !lastDay.isSame(dayjs(begin), "day");
+  const allDayLabel = intl.formatMessage({ id: "event.allDayLabel" });
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: "8px" }}>
@@ -51,10 +53,21 @@ export const TimeRenderer = ({
         <Typography>
           {allDay
             ? isMultiDay
-              ? `${dayjs(begin).format("ddd, DD MMM")} – ${lastDay.format(
-                  "ddd, DD MMM YYYY",
-                )} ⋅ All day`
-              : `${dayjs(begin).format("ddd, DD MMMM YYYY")} ⋅ All day`
+              ? intl.formatMessage(
+                  { id: "event.allDayDateRange" },
+                  {
+                    start: dayjs(begin).format("ddd, DD MMM"),
+                    end: lastDay.format("ddd, DD MMM YYYY"),
+                    label: allDayLabel,
+                  },
+                )
+              : intl.formatMessage(
+                  { id: "event.allDayDate" },
+                  {
+                    date: dayjs(begin).format("ddd, DD MMMM YYYY"),
+                    label: allDayLabel,
+                  },
+                )
             : `${dayjs(begin).format(
                 "ddd, DD MMMM YYYY ⋅ HH:mm -",
               )} ${dayjs(end).format("HH:mm")}`}

--- a/src/components/WeekView.tsx
+++ b/src/components/WeekView.tsx
@@ -17,6 +17,7 @@ import { TimeMarker } from "./TimeMarker";
 import { useRef, useState } from "react";
 import CalendarEventEdit from "./CalendarEventEdit";
 import { ViewProps } from "./SwipeableView";
+import { useIntl } from "react-intl";
 
 dayjs.extend(weekday);
 dayjs.extend(isSameOrBefore);
@@ -57,6 +58,7 @@ export const WeekHeader = ({ date }: { date: Dayjs }) => {
 };
 
 export function WeekView({ events, date }: ViewProps) {
+  const intl = useIntl();
   const start = date.startOf("week");
 
   const days = Array.from({ length: 7 }, (_, i) => start.add(i, "day"));
@@ -102,7 +104,7 @@ export function WeekView({ events, date }: ViewProps) {
             flexShrink={0}
           >
             <Typography variant="caption" sx={{ color: "text.secondary" }}>
-              all-day
+              {intl.formatMessage({ id: "event.allDayLabel" })}
             </Typography>
           </Box>
           <Box flex={1} display="grid" gridTemplateColumns="repeat(7, 1fr)">

--- a/src/components/WeekView.tsx
+++ b/src/components/WeekView.tsx
@@ -9,7 +9,7 @@ import {
   getTimeFromCell,
   layoutDayEvents,
 } from "../common/calendarEngine";
-import { CalendarEventCard } from "./CalendarEvent";
+import { AllDayEventChip, CalendarEventCard } from "./CalendarEvent";
 import { DateLabel } from "./DateLabel";
 import { isWeekend } from "../utils/dateHelper";
 import { StyledSecondaryHeader } from "./StyledComponents";
@@ -75,70 +75,114 @@ export function WeekView({ events, date }: ViewProps) {
 
   const theme = useTheme();
 
+  const DAY_MS = 24 * 60 * 60 * 1000;
+  const allDayForDay = (dayStartMs: number) =>
+    events.filter(
+      (e) => e.allDay && e.begin < dayStartMs + DAY_MS && e.end > dayStartMs,
+    );
+  const timedEvents = events.filter((e) => !e.allDay);
+
+  const hasAnyAllDay = days.some(
+    (day) => allDayForDay(day.startOf("day").valueOf()).length > 0,
+  );
+
   return (
-    <DndContext>
-      <Box display="flex" height={24 * 60}>
-        {/* Time column */}
-        <Box width={60} position={"relative"}>
-          <TimeMarker />
-          {Array.from({ length: 24 }).map((_, h) => (
-            <Box key={h} height={60} px={0.5}>
-              <Typography variant="caption">{h}:00</Typography>
-            </Box>
-          ))}
-        </Box>
-
-        {/* Days */}
-        <Box flex={1} display="grid" gridTemplateColumns="repeat(7, 1fr)">
-          {days.map((day) => {
-            const laidOut = layoutDayEvents(
-              getEventSegmentsForDay(events, day.startOf("day").valueOf()),
-            );
-
-            return (
-              <Box
-                key={day.toString()}
-                position="relative"
-                borderLeft="1px solid #eee"
-                ref={containerRef}
-                sx={{
-                  cursor: "pointer",
-                  background: isWeekend(day)
-                    ? alpha(theme.palette.primary.main, 0.1)
-                    : "transparent",
-                }}
-              >
-                {/* Day header */}
-
-                {day.isSame(dayjs(), "day") && <TimeMarker />}
-                {Array.from({ length: 24 }).map((_, h) => (
-                  <Box
-                    onClick={handleCellClick}
-                    data-date={day.format("YYYY-MM-DD")}
-                    key={h}
-                    height={60}
-                    px={0.5}
-                  >
-                    <Divider />
-                  </Box>
-                ))}
-                {laidOut.map((e) => (
-                  <CalendarEventCard key={e.renderKey} event={e} />
+    <>
+      {hasAnyAllDay && (
+        <Box
+          display="flex"
+          sx={{ borderBottom: "1px solid #ddd", minHeight: 24 }}
+        >
+          <Box
+            width={60}
+            borderRight="1px solid #ddd"
+            display="flex"
+            alignItems="center"
+            justifyContent="center"
+            flexShrink={0}
+          >
+            <Typography variant="caption" sx={{ color: "text.secondary" }}>
+              all-day
+            </Typography>
+          </Box>
+          <Box flex={1} display="grid" gridTemplateColumns="repeat(7, 1fr)">
+            {days.map((day) => (
+              <Box key={day.toString()} p={0.5} borderLeft="1px solid #eee">
+                {allDayForDay(day.startOf("day").valueOf()).map((evt) => (
+                  <AllDayEventChip key={`${evt.id}:${evt.begin}`} event={evt} />
                 ))}
               </Box>
-            );
-          })}
+            ))}
+          </Box>
         </Box>
-      </Box>
-      {dialogOpen && (
-        <CalendarEventEdit
-          open={dialogOpen}
-          event={null}
-          initialDateTime={clickedDateTime}
-          onClose={() => setDialogOpen(false)}
-          mode="create"
-        />
       )}
-    </DndContext>
+      <DndContext>
+        <Box display="flex" height={24 * 60}>
+          {/* Time column */}
+          <Box width={60} position={"relative"}>
+            <TimeMarker />
+            {Array.from({ length: 24 }).map((_, h) => (
+              <Box key={h} height={60} px={0.5}>
+                <Typography variant="caption">{h}:00</Typography>
+              </Box>
+            ))}
+          </Box>
+
+          {/* Days */}
+          <Box flex={1} display="grid" gridTemplateColumns="repeat(7, 1fr)">
+            {days.map((day) => {
+              const laidOut = layoutDayEvents(
+                getEventSegmentsForDay(
+                  timedEvents,
+                  day.startOf("day").valueOf(),
+                ),
+              );
+
+              return (
+                <Box
+                  key={day.toString()}
+                  position="relative"
+                  borderLeft="1px solid #eee"
+                  ref={containerRef}
+                  sx={{
+                    cursor: "pointer",
+                    background: isWeekend(day)
+                      ? alpha(theme.palette.primary.main, 0.1)
+                      : "transparent",
+                  }}
+                >
+                  {/* Day header */}
+
+                  {day.isSame(dayjs(), "day") && <TimeMarker />}
+                  {Array.from({ length: 24 }).map((_, h) => (
+                    <Box
+                      onClick={handleCellClick}
+                      data-date={day.format("YYYY-MM-DD")}
+                      key={h}
+                      height={60}
+                      px={0.5}
+                    >
+                      <Divider />
+                    </Box>
+                  ))}
+                  {laidOut.map((e) => (
+                    <CalendarEventCard key={e.renderKey} event={e} />
+                  ))}
+                </Box>
+              );
+            })}
+          </Box>
+        </Box>
+        {dialogOpen && (
+          <CalendarEventEdit
+            open={dialogOpen}
+            event={null}
+            initialDateTime={clickedDateTime}
+            onClose={() => setDialogOpen(false)}
+            mode="create"
+          />
+        )}
+      </DndContext>
+    </>
   );
 }

--- a/src/components/createEditEvent.ts
+++ b/src/components/createEditEvent.ts
@@ -13,6 +13,10 @@ export default async function createEditEvent({
   event: React.MouseEvent<HTMLDivElement>;
 }): Promise<ICalendarEvent | null> {
   if (calendarEvent) {
+    if (calendarEvent.source === "device") {
+      // Device-sourced events are read-only and have no Nostr identity.
+      return null;
+    }
     return {
       ...calendarEvent,
     };

--- a/src/hooks/useVisibleDeviceEvents.ts
+++ b/src/hooks/useVisibleDeviceEvents.ts
@@ -1,0 +1,98 @@
+import { useEffect } from "react";
+import type { Dayjs } from "dayjs";
+import type { Layout } from "./useLayout";
+import { useDeviceCalendars } from "../stores/deviceCalendars";
+import { DeviceCalendar } from "../plugins/deviceCalendar";
+import { deviceCalendarIdFor } from "../utils/deviceCalendarAdapter";
+
+function getDeviceEventRange(date: Dayjs, layout: Layout) {
+  let rangeStart = date.startOf("day");
+  let rangeEnd = date.endOf("day");
+
+  if (layout === "week") {
+    rangeStart = date.startOf("week").startOf("day");
+    rangeEnd = date.endOf("week").endOf("day");
+  } else if (layout === "month") {
+    rangeStart = date.startOf("month").startOf("week").startOf("day");
+    rangeEnd = date.endOf("month").endOf("week").endOf("day");
+  }
+
+  return {
+    // Pad by a day on each side so spanning all-day and overnight events are
+    // present when the visible range clips them at the boundary.
+    startMs: rangeStart.subtract(1, "day").valueOf(),
+    endMs: rangeEnd.add(1, "day").valueOf(),
+  };
+}
+
+export function useVisibleDeviceEvents(date: Dayjs, layout: Layout) {
+  const deviceInit = useDeviceCalendars((state) => state.init);
+  const deviceSyncPermission = useDeviceCalendars(
+    (state) => state.syncPermission,
+  );
+  const deviceRefreshEvents = useDeviceCalendars(
+    (state) => state.refreshEvents,
+  );
+  const devicePermission = useDeviceCalendars((state) => state.permission);
+  const deviceCalendars = useDeviceCalendars((state) => state.calendars);
+  const deviceVisibility = useDeviceCalendars((state) => state.visibility);
+  const deviceEvents = useDeviceCalendars((state) => state.events);
+
+  useEffect(() => {
+    void deviceInit();
+  }, [deviceInit]);
+
+  useEffect(() => {
+    if (!DeviceCalendar.isAvailable()) {
+      return;
+    }
+
+    let cancelled = false;
+    let removeResume: (() => Promise<void>) | undefined;
+
+    void (async () => {
+      try {
+        const { App: CapacitorApp } = await import("@capacitor/app");
+        const listener = await CapacitorApp.addListener("resume", () => {
+          void deviceSyncPermission();
+        });
+
+        if (cancelled) {
+          void listener.remove();
+          return;
+        }
+
+        removeResume = () => listener.remove();
+      } catch {
+        // Ignore on platforms where lifecycle events are unavailable.
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      void removeResume?.();
+    };
+  }, [deviceSyncPermission]);
+
+  useEffect(() => {
+    if (devicePermission !== "granted") return;
+    void deviceRefreshEvents(getDeviceEventRange(date, layout));
+  }, [
+    date,
+    deviceCalendars,
+    devicePermission,
+    deviceRefreshEvents,
+    deviceVisibility,
+    layout,
+  ]);
+
+  const visibleDeviceCalendarIds = new Set(
+    deviceCalendars
+      .filter((calendar) => deviceVisibility[calendar.id] !== false)
+      .map((calendar) => deviceCalendarIdFor(calendar.id)),
+  );
+
+  return deviceEvents.filter((event) =>
+    visibleDeviceCalendarIds.has(event.calendarId ?? ""),
+  );
+}

--- a/src/plugins/deviceCalendar.ts
+++ b/src/plugins/deviceCalendar.ts
@@ -1,0 +1,107 @@
+import { Capacitor, registerPlugin } from "@capacitor/core";
+
+/**
+ * Bridge to the device's native calendar database.
+ *
+ * Android: backed by `CalendarContract` (Calendars + Instances + Events).
+ * iOS: not implemented yet — `isAvailable()` returns false on non-Android.
+ * Web: not implemented — calls reject; UI must gate on `isAvailable()`.
+ */
+
+export type DeviceCalendarPermissionState =
+  | "granted"
+  | "denied"
+  | "prompt"
+  | "prompt-with-rationale";
+
+export interface DeviceCalendarPermissionStatus {
+  calendar: DeviceCalendarPermissionState;
+}
+
+export interface DeviceCalendarInfo {
+  /** Native calendar id (string form). */
+  id: string;
+  /** Display name shown in the system calendar app. */
+  name: string;
+  /** Owning account name (e.g. Google account email). */
+  accountName: string;
+  /** Hex color string `#RRGGBB`, falls back to `#4285f4` when missing. */
+  color: string;
+  /** True if this calendar is the user's primary one for its account. */
+  isPrimary: boolean;
+  /** True if events can be inserted into this calendar (access level >= contributor). */
+  canWrite: boolean;
+}
+
+export interface DeviceCalendarEvent {
+  /** Native event/instance id. Unique per occurrence (recurring events expand to many). */
+  id: string;
+  /** Native calendar id this event belongs to. */
+  calendarId: string;
+  title: string;
+  description: string;
+  location: string;
+  /** Begin time, milliseconds since epoch (UTC). */
+  beginMs: number;
+  /** End time, milliseconds since epoch (UTC). */
+  endMs: number;
+  allDay: boolean;
+  organizer: string;
+  /** RRULE string if the source event is recurring; undefined for one-off events. */
+  rrule?: string;
+}
+
+export interface ListEventsOptions {
+  /** Native calendar ids to query. Empty array = all calendars. */
+  calendarIds: string[];
+  startMs: number;
+  endMs: number;
+}
+
+export interface DeviceCalendarPluginShape {
+  checkPermissions(): Promise<DeviceCalendarPermissionStatus>;
+  requestPermissions(): Promise<DeviceCalendarPermissionStatus>;
+  listCalendars(): Promise<{ calendars: DeviceCalendarInfo[] }>;
+  listEvents(
+    options: ListEventsOptions,
+  ): Promise<{ events: DeviceCalendarEvent[] }>;
+  openAppSettings(): Promise<void>;
+}
+
+const deviceCalendar =
+  registerPlugin<DeviceCalendarPluginShape>("DeviceCalendar");
+
+/** True only on platforms where the native plugin is implemented. */
+export function isAvailable(): boolean {
+  return Capacitor.getPlatform() === "android";
+}
+
+export const DeviceCalendar = {
+  isAvailable,
+  async checkPermissions(): Promise<DeviceCalendarPermissionStatus> {
+    if (!isAvailable()) return { calendar: "denied" };
+    return deviceCalendar.checkPermissions();
+  },
+  async requestPermissions(): Promise<DeviceCalendarPermissionStatus> {
+    if (!isAvailable()) return { calendar: "denied" };
+    return deviceCalendar.requestPermissions();
+  },
+  async listCalendars(): Promise<DeviceCalendarInfo[]> {
+    if (!isAvailable()) return [];
+    const result = await deviceCalendar.listCalendars();
+    return result.calendars ?? [];
+  },
+  async listEvents(options: ListEventsOptions): Promise<DeviceCalendarEvent[]> {
+    if (!isAvailable()) return [];
+    const result = await deviceCalendar.listEvents(options);
+    return result.events ?? [];
+  },
+  /**
+   * Sends the user to the app's system settings page so they can re-enable
+   * calendar permission after Android stops surfacing the runtime dialog.
+   */
+  async openAppSettings(): Promise<void> {
+    if (!isAvailable()) return;
+    await deviceCalendar.openAppSettings();
+  },
+};

--- a/src/plugins/deviceCalendar.ts
+++ b/src/plugins/deviceCalendar.ts
@@ -65,7 +65,6 @@ export interface DeviceCalendarPluginShape {
   listEvents(
     options: ListEventsOptions,
   ): Promise<{ events: DeviceCalendarEvent[] }>;
-  openAppSettings(): Promise<void>;
 }
 
 const deviceCalendar =
@@ -95,13 +94,5 @@ export const DeviceCalendar = {
     if (!isAvailable()) return [];
     const result = await deviceCalendar.listEvents(options);
     return result.events ?? [];
-  },
-  /**
-   * Sends the user to the app's system settings page so they can re-enable
-   * calendar permission after Android stops surfacing the runtime dialog.
-   */
-  async openAppSettings(): Promise<void> {
-    if (!isAvailable()) return;
-    await deviceCalendar.openAppSettings();
   },
 };

--- a/src/stores/deviceCalendars.ts
+++ b/src/stores/deviceCalendars.ts
@@ -27,12 +27,6 @@ interface DeviceCalendarsState {
   available: boolean;
   /** Permission state mirrored from the native side. */
   permission: DeviceCalendarPermissionState | "unknown";
-  /**
-   * True once the user has explicitly denied a request in-app and Android is
-   * no longer surfacing the OS dialog. Drives the "Open settings" recovery
-   * UI in the sidebar.
-   */
-  permanentlyDenied: boolean;
   calendars: DeviceCalendarInfo[];
   /** Native -> visible flag, persisted to localStorage. Default-on once discovered. */
   visibility: Visibility;
@@ -44,12 +38,44 @@ interface DeviceCalendarsState {
   init: () => Promise<void>;
   syncPermission: () => Promise<void>;
   requestAccess: () => Promise<void>;
-  openAppSettings: () => Promise<void>;
   refreshCalendars: () => Promise<void>;
   refreshEvents: (range: { startMs: number; endMs: number }) => Promise<void>;
   toggleVisibility: (nativeCalendarId: string) => void;
   setAllVisibility: (visible: boolean) => void;
 }
+
+const DEVICE_CALENDAR_ERROR_MESSAGES = {
+  invalidCalendarIds: "deviceCalendar.errorInvalidCalendarIds",
+  invalidRange: "deviceCalendar.errorInvalidRange",
+  permissionDenied: "deviceCalendar.errorPermissionDenied",
+  readCalendars: "deviceCalendar.errorReadCalendars",
+  readEvents: "deviceCalendar.errorReadEvents",
+  unknown: "deviceCalendar.errorUnknown",
+} as const;
+
+const normalizeDeviceCalendarError = (error: unknown): string => {
+  const message = error instanceof Error ? error.message : String(error);
+
+  if (message === "Calendar permission not granted") {
+    return DEVICE_CALENDAR_ERROR_MESSAGES.permissionDenied;
+  }
+  if (message === "Invalid calendarIds payload") {
+    return DEVICE_CALENDAR_ERROR_MESSAGES.invalidCalendarIds;
+  }
+  if (
+    message === "startMs and endMs are required, and endMs must be > startMs"
+  ) {
+    return DEVICE_CALENDAR_ERROR_MESSAGES.invalidRange;
+  }
+  if (message.startsWith("Failed to read calendars:")) {
+    return DEVICE_CALENDAR_ERROR_MESSAGES.readCalendars;
+  }
+  if (message.startsWith("Failed to read events:")) {
+    return DEVICE_CALENDAR_ERROR_MESSAGES.readEvents;
+  }
+
+  return DEVICE_CALENDAR_ERROR_MESSAGES.unknown;
+};
 
 const getInitialPermission = (): DeviceCalendarPermissionState | "unknown" => {
   if (!DeviceCalendar.isAvailable()) {
@@ -79,7 +105,6 @@ export const useDeviceCalendars = create<DeviceCalendarsState>((set, get) => {
   return {
     available: DeviceCalendar.isAvailable(),
     permission: getInitialPermission(),
-    permanentlyDenied: false,
     calendars: [],
     visibility: getItem<Visibility>(VISIBILITY_STORAGE_KEY, {}),
     events: [],
@@ -106,15 +131,9 @@ export const useDeviceCalendars = create<DeviceCalendarsState>((set, get) => {
       try {
         const status = await DeviceCalendar.checkPermissions();
         persistPermission(status.calendar);
-        // syncPermission runs on app resume etc.; we never *infer* permanent
-        // denial here, only requestAccess can flip the flag, and only granted
-        // can clear it.
         set({
           available: true,
           permission: status.calendar,
-          ...(status.calendar === "granted"
-            ? { permanentlyDenied: false }
-            : {}),
         });
         if (status.calendar === "granted") {
           await get().refreshCalendars();
@@ -123,27 +142,16 @@ export const useDeviceCalendars = create<DeviceCalendarsState>((set, get) => {
           set({ events: [] });
         }
       } catch (e) {
-        set({ error: (e as Error).message });
+        set({ error: normalizeDeviceCalendarError(e) });
       }
     },
 
     async requestAccess() {
       if (!DeviceCalendar.isAvailable()) return;
-      const previous = get().permission;
       try {
         const status = await DeviceCalendar.requestPermissions();
         persistPermission(status.calendar);
-        // If the user was already "denied" before this call and the OS still
-        // returned "denied" without a prompt, treat it as permanently denied.
-        // "prompt-with-rationale" still has a path forward via another request,
-        // so it is not considered permanent.
-        const permanentlyDenied =
-          status.calendar === "denied" && previous === "denied";
-        set({
-          permission: status.calendar,
-          permanentlyDenied:
-            status.calendar === "granted" ? false : permanentlyDenied,
-        });
+        set({ permission: status.calendar });
         if (status.calendar === "granted") {
           await get().refreshCalendars();
         } else {
@@ -151,15 +159,7 @@ export const useDeviceCalendars = create<DeviceCalendarsState>((set, get) => {
           set({ events: [] });
         }
       } catch (e) {
-        set({ error: (e as Error).message });
-      }
-    },
-
-    async openAppSettings() {
-      try {
-        await DeviceCalendar.openAppSettings();
-      } catch (e) {
-        set({ error: (e as Error).message });
+        set({ error: normalizeDeviceCalendarError(e) });
       }
     },
 
@@ -181,7 +181,7 @@ export const useDeviceCalendars = create<DeviceCalendarsState>((set, get) => {
         if (changed) setItem(VISIBILITY_STORAGE_KEY, next);
         set({ calendars, visibility: next, loading: false });
       } catch (e) {
-        set({ loading: false, error: (e as Error).message });
+        set({ loading: false, error: normalizeDeviceCalendarError(e) });
       }
     },
 
@@ -213,7 +213,7 @@ export const useDeviceCalendars = create<DeviceCalendarsState>((set, get) => {
         set({ events: native.map(deviceEventToCalendarEvent) });
       } catch (e) {
         if (generation !== refreshGeneration) return;
-        set({ error: (e as Error).message });
+        set({ error: normalizeDeviceCalendarError(e) });
       }
     },
 

--- a/src/stores/deviceCalendars.ts
+++ b/src/stores/deviceCalendars.ts
@@ -1,0 +1,241 @@
+/**
+ * Device Calendars Store
+ *
+ * Holds calendars and events read from the phone's native calendar database
+ * via the `DeviceCalendar` Capacitor plugin. Lives in its own store so that
+ * device-sourced events never enter the Nostr publish/RSVP code paths in
+ * `useTimeBasedEvents`. Merged into rendering at the `Calendar.tsx` boundary.
+ */
+
+import { create } from "zustand";
+import { getItem, setItem } from "../common/localStorage";
+import {
+  DeviceCalendar,
+  type DeviceCalendarInfo,
+  type DeviceCalendarPermissionState,
+} from "../plugins/deviceCalendar";
+import { deviceEventToCalendarEvent } from "../utils/deviceCalendarAdapter";
+import type { ICalendarEvent } from "../utils/types";
+
+const VISIBILITY_STORAGE_KEY = "cal:device_visibility";
+const PERMISSION_STORAGE_KEY = "cal:device_permission";
+
+type Visibility = Record<string, boolean>;
+
+interface DeviceCalendarsState {
+  /** Whether the native bridge is implemented on this platform. */
+  available: boolean;
+  /** Permission state mirrored from the native side. */
+  permission: DeviceCalendarPermissionState | "unknown";
+  /**
+   * True once the user has explicitly denied a request in-app and Android is
+   * no longer surfacing the OS dialog. Drives the "Open settings" recovery
+   * UI in the sidebar.
+   */
+  permanentlyDenied: boolean;
+  calendars: DeviceCalendarInfo[];
+  /** Native -> visible flag, persisted to localStorage. Default-on once discovered. */
+  visibility: Visibility;
+  /** Already converted to ICalendarEvent. */
+  events: ICalendarEvent[];
+  loading: boolean;
+  error?: string;
+
+  init: () => Promise<void>;
+  syncPermission: () => Promise<void>;
+  requestAccess: () => Promise<void>;
+  openAppSettings: () => Promise<void>;
+  refreshCalendars: () => Promise<void>;
+  refreshEvents: (range: { startMs: number; endMs: number }) => Promise<void>;
+  toggleVisibility: (nativeCalendarId: string) => void;
+  setAllVisibility: (visible: boolean) => void;
+}
+
+const getInitialPermission = (): DeviceCalendarPermissionState | "unknown" => {
+  if (!DeviceCalendar.isAvailable()) {
+    return "denied";
+  }
+  return getItem<DeviceCalendarPermissionState | "unknown">(
+    PERMISSION_STORAGE_KEY,
+    "unknown",
+  );
+};
+
+const persistPermission = (
+  permission: DeviceCalendarPermissionState | "unknown",
+) => {
+  setItem(PERMISSION_STORAGE_KEY, permission);
+};
+
+export const useDeviceCalendars = create<DeviceCalendarsState>((set, get) => {
+  // Monotonic token used to drop stale `listEvents` responses when a newer
+  // refresh has been kicked off (e.g. user toggling a calendar twice quickly).
+  let refreshGeneration = 0;
+
+  const invalidateEventQueries = () => {
+    refreshGeneration += 1;
+  };
+
+  return {
+    available: DeviceCalendar.isAvailable(),
+    permission: getInitialPermission(),
+    permanentlyDenied: false,
+    calendars: [],
+    visibility: getItem<Visibility>(VISIBILITY_STORAGE_KEY, {}),
+    events: [],
+    loading: false,
+    error: undefined,
+
+    async init() {
+      if (!DeviceCalendar.isAvailable()) {
+        persistPermission("denied");
+        invalidateEventQueries();
+        set({ available: false, permission: "denied", events: [] });
+        return;
+      }
+      await get().syncPermission();
+    },
+
+    async syncPermission() {
+      if (!DeviceCalendar.isAvailable()) {
+        persistPermission("denied");
+        invalidateEventQueries();
+        set({ available: false, permission: "denied", events: [] });
+        return;
+      }
+      try {
+        const status = await DeviceCalendar.checkPermissions();
+        persistPermission(status.calendar);
+        // syncPermission runs on app resume etc.; we never *infer* permanent
+        // denial here, only requestAccess can flip the flag, and only granted
+        // can clear it.
+        set({
+          available: true,
+          permission: status.calendar,
+          ...(status.calendar === "granted"
+            ? { permanentlyDenied: false }
+            : {}),
+        });
+        if (status.calendar === "granted") {
+          await get().refreshCalendars();
+        } else {
+          invalidateEventQueries();
+          set({ events: [] });
+        }
+      } catch (e) {
+        set({ error: (e as Error).message });
+      }
+    },
+
+    async requestAccess() {
+      if (!DeviceCalendar.isAvailable()) return;
+      const previous = get().permission;
+      try {
+        const status = await DeviceCalendar.requestPermissions();
+        persistPermission(status.calendar);
+        // If the user was already "denied" before this call and the OS still
+        // returned "denied" without a prompt, treat it as permanently denied.
+        // "prompt-with-rationale" still has a path forward via another request,
+        // so it is not considered permanent.
+        const permanentlyDenied =
+          status.calendar === "denied" && previous === "denied";
+        set({
+          permission: status.calendar,
+          permanentlyDenied:
+            status.calendar === "granted" ? false : permanentlyDenied,
+        });
+        if (status.calendar === "granted") {
+          await get().refreshCalendars();
+        } else {
+          invalidateEventQueries();
+          set({ events: [] });
+        }
+      } catch (e) {
+        set({ error: (e as Error).message });
+      }
+    },
+
+    async openAppSettings() {
+      try {
+        await DeviceCalendar.openAppSettings();
+      } catch (e) {
+        set({ error: (e as Error).message });
+      }
+    },
+
+    async refreshCalendars() {
+      if (get().permission !== "granted") return;
+      set({ loading: true, error: undefined });
+      try {
+        const calendars = await DeviceCalendar.listCalendars();
+        // Default any newly-discovered calendar to visible.
+        const current = get().visibility;
+        const next: Visibility = { ...current };
+        let changed = false;
+        for (const c of calendars) {
+          if (next[c.id] === undefined) {
+            next[c.id] = true;
+            changed = true;
+          }
+        }
+        if (changed) setItem(VISIBILITY_STORAGE_KEY, next);
+        set({ calendars, visibility: next, loading: false });
+      } catch (e) {
+        set({ loading: false, error: (e as Error).message });
+      }
+    },
+
+    async refreshEvents({ startMs, endMs }) {
+      if (get().permission !== "granted") {
+        invalidateEventQueries();
+        set({ events: [] });
+        return;
+      }
+      const visible = get().visibility;
+      const calendarIds = get()
+        .calendars.filter((c) => visible[c.id] !== false)
+        .map((c) => c.id);
+      if (calendarIds.length === 0) {
+        invalidateEventQueries();
+        set({ events: [] });
+        return;
+      }
+      const generation = ++refreshGeneration;
+      try {
+        const native = await DeviceCalendar.listEvents({
+          calendarIds,
+          startMs,
+          endMs,
+        });
+        // Drop stale responses: a newer refresh has been kicked off in the
+        // meantime (e.g. user toggled visibility twice quickly).
+        if (generation !== refreshGeneration) return;
+        set({ events: native.map(deviceEventToCalendarEvent) });
+      } catch (e) {
+        if (generation !== refreshGeneration) return;
+        set({ error: (e as Error).message });
+      }
+    },
+
+    toggleVisibility(nativeCalendarId) {
+      const current = get().visibility;
+      const next = {
+        ...current,
+        [nativeCalendarId]: !(current[nativeCalendarId] ?? true),
+      };
+      invalidateEventQueries();
+      setItem(VISIBILITY_STORAGE_KEY, next);
+      set({ visibility: next });
+    },
+
+    setAllVisibility(visible) {
+      const next: Visibility = { ...get().visibility };
+      for (const calendar of get().calendars) {
+        next[calendar.id] = visible;
+      }
+      invalidateEventQueries();
+      setItem(VISIBILITY_STORAGE_KEY, next);
+      set({ visibility: next });
+    },
+  };
+});

--- a/src/utils/deviceCalendarAdapter.test.ts
+++ b/src/utils/deviceCalendarAdapter.test.ts
@@ -72,9 +72,9 @@ describe("deviceCalendarAdapter", () => {
     expect(deviceEventToCalendarEvent(noLoc).location).toEqual([]);
   });
 
-  it("provides a placeholder title for events with no name", () => {
+  it("preserves an empty title when the native event has no name", () => {
     const noTitle = { ...baseEvent, title: "" };
-    expect(deviceEventToCalendarEvent(noTitle).title).toBe("(No title)");
+    expect(deviceEventToCalendarEvent(noTitle).title).toBe("");
   });
 
   it("returns a fallback color for invalid hex input", () => {

--- a/src/utils/deviceCalendarAdapter.test.ts
+++ b/src/utils/deviceCalendarAdapter.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import {
+  DEVICE_CALENDAR_ID_PREFIX,
+  deviceCalendarColor,
+  deviceCalendarIdFor,
+  deviceEventToCalendarEvent,
+} from "./deviceCalendarAdapter";
+import type {
+  DeviceCalendarEvent,
+  DeviceCalendarInfo,
+} from "../plugins/deviceCalendar";
+
+const baseInfo: DeviceCalendarInfo = {
+  id: "42",
+  name: "Work",
+  accountName: "user@example.com",
+  color: "#4285F4",
+  isPrimary: true,
+  canWrite: true,
+};
+
+const baseEvent: DeviceCalendarEvent = {
+  id: "100:42",
+  calendarId: "42",
+  title: "Standup",
+  description: "Daily team sync",
+  location: "HQ",
+  beginMs: 1_700_000_000_000,
+  endMs: 1_700_000_900_000,
+  allDay: false,
+  organizer: "alice@example.com",
+};
+
+describe("deviceCalendarAdapter", () => {
+  it("namespaces native calendar ids", () => {
+    expect(deviceCalendarIdFor("42")).toBe(`${DEVICE_CALENDAR_ID_PREFIX}42`);
+  });
+
+  it("normalizes a native event into ICalendarEvent shape", () => {
+    const ce = deviceEventToCalendarEvent(baseEvent);
+    expect(ce.source).toBe("device");
+    expect(ce.allDay).toBe(false);
+    expect(ce.calendarId).toBe(`${DEVICE_CALENDAR_ID_PREFIX}42`);
+    expect(ce.title).toBe("Standup");
+    expect(ce.begin).toBe(baseEvent.beginMs);
+    expect(ce.end).toBe(baseEvent.endMs);
+    expect(ce.location).toEqual(["HQ"]);
+    expect(ce.user).toBe("alice@example.com");
+    // Nostr-only fields default safely.
+    expect(ce.eventId).toBe("");
+    expect(ce.kind).toBe(-1);
+    expect(ce.isPrivateEvent).toBe(false);
+    expect(ce.repeat).toEqual({ rrule: null });
+    expect(ce.rsvpResponses).toEqual([]);
+  });
+
+  it("preserves all-day events as allDay=true", () => {
+    const allDay = { ...baseEvent, allDay: true };
+    expect(deviceEventToCalendarEvent(allDay).allDay).toBe(true);
+  });
+
+  it("preserves rrule when present and falls back to null otherwise", () => {
+    const recurring = { ...baseEvent, rrule: "FREQ=DAILY;COUNT=5" };
+    expect(deviceEventToCalendarEvent(recurring).repeat.rrule).toBe(
+      "FREQ=DAILY;COUNT=5",
+    );
+    expect(deviceEventToCalendarEvent(baseEvent).repeat.rrule).toBeNull();
+  });
+
+  it("emits an empty location array when the native location is empty", () => {
+    const noLoc = { ...baseEvent, location: "" };
+    expect(deviceEventToCalendarEvent(noLoc).location).toEqual([]);
+  });
+
+  it("provides a placeholder title for events with no name", () => {
+    const noTitle = { ...baseEvent, title: "" };
+    expect(deviceEventToCalendarEvent(noTitle).title).toBe("(No title)");
+  });
+
+  it("returns a fallback color for invalid hex input", () => {
+    expect(deviceCalendarColor(baseInfo)).toBe("#4285F4");
+    expect(deviceCalendarColor({ ...baseInfo, color: "" })).toBe("#4285f4");
+    expect(deviceCalendarColor({ ...baseInfo, color: "not a color" })).toBe(
+      "#4285f4",
+    );
+  });
+});

--- a/src/utils/deviceCalendarAdapter.ts
+++ b/src/utils/deviceCalendarAdapter.ts
@@ -29,7 +29,7 @@ export function deviceEventToCalendarEvent(
     id: evt.id,
     eventId: "",
     kind: -1,
-    title: evt.title || "(No title)",
+    title: evt.title || "",
     description: evt.description || "",
     begin: evt.beginMs,
     end: evt.endMs,

--- a/src/utils/deviceCalendarAdapter.ts
+++ b/src/utils/deviceCalendarAdapter.ts
@@ -1,0 +1,61 @@
+import type { ICalendarEvent } from "./types";
+import type {
+  DeviceCalendarEvent,
+  DeviceCalendarInfo,
+} from "../plugins/deviceCalendar";
+
+/**
+ * Synthetic calendarId namespace for device events. Lets the existing
+ * visibility filter in `Calendar.tsx` work without source-specific code paths.
+ */
+export const DEVICE_CALENDAR_ID_PREFIX = "device:";
+
+export function deviceCalendarIdFor(nativeId: string): string {
+  return `${DEVICE_CALENDAR_ID_PREFIX}${nativeId}`;
+}
+
+/**
+ * Convert a native event into the app's `ICalendarEvent` shape.
+ *
+ * Nostr-only fields (eventId, viewKey, rsvpResponses, etc.) are populated with
+ * inert defaults. The `source: "device"` flag is the canonical read-only check.
+ * `kind` is set to `-1` as a sentinel; rendering code already only branches on
+ * `source` / `isInvitation`, never on the raw kind.
+ */
+export function deviceEventToCalendarEvent(
+  evt: DeviceCalendarEvent,
+): ICalendarEvent {
+  return {
+    id: evt.id,
+    eventId: "",
+    kind: -1,
+    title: evt.title || "(No title)",
+    description: evt.description || "",
+    begin: evt.beginMs,
+    end: evt.endMs,
+    createdAt: 0,
+    categories: [],
+    participants: [],
+    rsvpResponses: [],
+    reference: [],
+    image: undefined,
+    location: evt.location ? [evt.location] : [],
+    geoHash: [],
+    website: "",
+    user: evt.organizer || "",
+    isPrivateEvent: false,
+    repeat: { rrule: evt.rrule ?? null },
+    calendarId: deviceCalendarIdFor(evt.calendarId),
+    allDay: evt.allDay,
+    source: "device",
+  };
+}
+
+/**
+ * Stable display color for a device calendar. Falls back to a neutral blue if
+ * the native side returned an empty/invalid color.
+ */
+export function deviceCalendarColor(info: DeviceCalendarInfo): string {
+  const c = (info.color || "").trim();
+  return /^#[0-9a-f]{6}$/i.test(c) ? c : "#4285f4";
+}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -66,4 +66,11 @@ export interface ICalendarEvent {
   calendarId?: string;
   isInvitation?: boolean;
   relayHint?: string;
+  allDay?: boolean;
+  /**
+   * Origin of this event. Defaults to "nostr" when undefined for backwards
+   * compatibility. "device" events are read-only and must never enter the
+   * Nostr publish/RSVP code paths.
+   */
+  source?: "nostr" | "device";
 }


### PR DESCRIPTION
Adds an in-repo Capacitor plugin (`DeviceCalendar`) that reads the Android phone's native calendars and merges their events into the existing Day / Week / Month views.