### PR TITLE
feat(forms): persist form attachments on private calendar events

### DIFF
--- a/src/common/dictionary.ts
+++ b/src/common/dictionary.ts
@@ -110,6 +110,14 @@ const dictionary: NestedObject = {
       notInCalendar:
         "This event is not in any of your calendars. You will not receive notifications for this event. Add it to your calendar to receive notifications.",
       scheduledNotifications: "Scheduled Notifications",
+      forms: "Forms",
+      attachForm: "Attach form",
+      formInputPlaceholder: "Paste form naddr or Formstr URL",
+      addForm: "Add",
+      removeForm: "Remove form",
+      invalidFormInput: "Could not recognize a form naddr in that input.",
+      duplicateFormInput: "That form is already attached.",
+      formsPrivateOnly: "Forms can only be attached to private events.",
     },
     deleteEvent: {
       title: "Delete Event",
@@ -320,6 +328,15 @@ const dictionary: NestedObject = {
       notInCalendar:
         "Dieser Termin ist in keinem Ihrer Kalender. Sie erhalten keine Benachrichtigungen für diesen Termin. Fügen Sie ihn zu Ihrem Kalender hinzu, um Benachrichtigungen zu erhalten.",
       scheduledNotifications: "Geplante Benachrichtigungen",
+      forms: "Formulare",
+      attachForm: "Formular anhängen",
+      formInputPlaceholder: "Formular-naddr oder Formstr-URL einfügen",
+      addForm: "Hinzufügen",
+      removeForm: "Formular entfernen",
+      invalidFormInput: "In der Eingabe wurde keine Formular-naddr erkannt.",
+      duplicateFormInput: "Dieses Formular ist bereits angehängt.",
+      formsPrivateOnly:
+        "Formulare können nur an private Termine angehängt werden.",
     },
     deleteEvent: {
       title: "Termin löschen",

--- a/src/common/nostr.ts
+++ b/src/common/nostr.ts
@@ -133,6 +133,18 @@ async function preparePrivateCalendarEvent(
     eventData.push(["notification", event.notificationPreference]);
   }
 
+  event.forms?.forEach((form) => {
+    if (!form?.naddr) return;
+    // viewKey is the form's read-only NIP-44 decryption key. We deliberately
+    // never persist a Formstr `responseKey` (admin/edit secret) on a calendar
+    // event \u2014 doing so would grant every recipient write access to the form.
+    if (form.viewKey) {
+      eventData.push(["form", form.naddr, form.viewKey]);
+    } else {
+      eventData.push(["form", form.naddr]);
+    }
+  });
+
   event.location.forEach((loc) => {
     eventData.push(["location", loc]);
   });

--- a/src/components/CalendarEventEdit.tsx
+++ b/src/components/CalendarEventEdit.tsx
@@ -43,6 +43,7 @@ import LocationPinIcon from "@mui/icons-material/LocationPin";
 import EventRepeatIcon from "@mui/icons-material/EventRepeat";
 import PeopleIcon from "@mui/icons-material/People";
 import DescriptionIcon from "@mui/icons-material/Description";
+import AssignmentIcon from "@mui/icons-material/Assignment";
 import { EventAttributeEditContainer } from "./StyledComponents";
 import LockIcon from "@mui/icons-material/Lock";
 import PublicIcon from "@mui/icons-material/Public";
@@ -53,6 +54,8 @@ import { useCalendarLists } from "../stores/calendarLists";
 import { useTimeBasedEvents } from "../stores/events";
 import { parseEventRef } from "../utils/calendarListTypes";
 import { CalendarListSelect } from "./CalendarListSelect";
+import { parseFormInput } from "../utils/formLink";
+import type { IFormAttachment } from "../utils/types";
 
 interface CalendarEventEditProps {
   open: boolean;
@@ -342,6 +345,8 @@ export function CalendarEventEdit({
       ? getCustomDraftFromRule(initialRule, dayjs(eventDetails.begin))
       : createDefaultCustomDraft(dayjs(eventDetails.begin)),
   );
+  const [formInput, setFormInput] = useState("");
+  const [formInputError, setFormInputError] = useState<string | null>(null);
 
   const handleClose = () => {
     onClose();
@@ -356,6 +361,30 @@ export function CalendarEventEdit({
     value: ICalendarEvent[K],
   ) => {
     setEventDetails((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const attachedForms: IFormAttachment[] = eventDetails.forms ?? [];
+
+  const handleAddForm = () => {
+    const parsed = parseFormInput(formInput);
+    if (!parsed) {
+      setFormInputError(intl.formatMessage({ id: "event.invalidFormInput" }));
+      return;
+    }
+    if (attachedForms.some((f) => f.naddr === parsed.naddr)) {
+      setFormInputError(intl.formatMessage({ id: "event.duplicateFormInput" }));
+      return;
+    }
+    updateField("forms", [...attachedForms, parsed]);
+    setFormInput("");
+    setFormInputError(null);
+  };
+
+  const handleRemoveForm = (naddr: string) => {
+    updateField(
+      "forms",
+      attachedForms.filter((f) => f.naddr !== naddr),
+    );
   };
 
   const openCustomDialog = () => {
@@ -1057,6 +1086,96 @@ export function CalendarEventEdit({
         </Box>
       </Box>
       <Divider />
+      {/* Attached Forms (private events only) */}
+      {isPrivate && (
+        <>
+          <Box>
+            <AssignmentIcon />
+            <Box style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+              <Typography variant="body2" style={{ fontWeight: 500 }}>
+                {intl.formatMessage({ id: "event.forms" })}
+              </Typography>
+
+              {attachedForms.length > 0 && (
+                <Box
+                  style={{ display: "flex", flexDirection: "column", gap: 8 }}
+                >
+                  {attachedForms.map((form) => (
+                    <Box
+                      key={form.naddr}
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "space-between",
+                        padding: "8px 12px",
+                        backgroundColor: "#f5f5f5",
+                        borderRadius: 4,
+                        gap: 8,
+                      }}
+                    >
+                      <Typography
+                        variant="body2"
+                        style={{
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          whiteSpace: "nowrap",
+                          flex: 1,
+                          fontFamily: "monospace",
+                        }}
+                        title={form.naddr}
+                      >
+                        {form.naddr}
+                      </Typography>
+                      <Button
+                        size="small"
+                        color="error"
+                        onClick={() => handleRemoveForm(form.naddr)}
+                      >
+                        {intl.formatMessage({ id: "event.removeForm" })}
+                      </Button>
+                    </Box>
+                  ))}
+                </Box>
+              )}
+
+              <Box
+                style={{ display: "flex", gap: 8, alignItems: "flex-start" }}
+              >
+                <TextField
+                  fullWidth
+                  size="small"
+                  placeholder={intl.formatMessage({
+                    id: "event.formInputPlaceholder",
+                  })}
+                  value={formInput}
+                  onChange={(e) => {
+                    setFormInput(e.target.value);
+                    if (formInputError) setFormInputError(null);
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      e.preventDefault();
+                      handleAddForm();
+                    }
+                  }}
+                  error={!!formInputError}
+                  helperText={formInputError ?? undefined}
+                />
+                <Button
+                  variant="outlined"
+                  size="small"
+                  onClick={handleAddForm}
+                  disabled={!formInput.trim()}
+                  style={{ marginTop: 0 }}
+                >
+                  {intl.formatMessage({ id: "event.addForm" })}
+                </Button>
+              </Box>
+            </Box>
+          </Box>
+          <Divider />
+        </>
+      )}
       {/* Description */}
       <Box>
         <DescriptionIcon />

--- a/src/utils/formLink.test.ts
+++ b/src/utils/formLink.test.ts
@@ -72,6 +72,14 @@ describe("extractViewKey", () => {
     ).toBe(SAMPLE_VIEW_KEY);
   });
 
+  it("normalizes ?viewKey query params to lowercase", () => {
+    expect(
+      extractViewKey(
+        `https://formstr.app/f/${SAMPLE_NADDR}?viewKey=${SAMPLE_VIEW_KEY.toUpperCase()}`,
+      ),
+    ).toBe(SAMPLE_VIEW_KEY);
+  });
+
   it("reads &viewKey when not the first param", () => {
     expect(
       extractViewKey(

--- a/src/utils/formLink.test.ts
+++ b/src/utils/formLink.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import { naddrEncode } from "nostr-tools/nip19";
+import {
+  buildFormstrUrl,
+  extractNaddr,
+  extractViewKey,
+  parseFormInput,
+} from "./formLink";
+
+const SAMPLE_PUBKEY = "0".repeat(63) + "1"; // valid 64-char hex
+const FORM_KIND = 30168;
+
+const SAMPLE_NADDR = naddrEncode({
+  kind: FORM_KIND,
+  pubkey: SAMPLE_PUBKEY,
+  identifier: "demo-form",
+  relays: [],
+});
+
+const SAMPLE_VIEW_KEY =
+  "4155adc1f08a7c0d425501a407f9e6c4f2babcdf3d002103531cd2f2de26c816";
+
+describe("extractNaddr", () => {
+  it("returns the naddr from a bare string", () => {
+    expect(extractNaddr(SAMPLE_NADDR)).toBe(SAMPLE_NADDR);
+  });
+
+  it("trims whitespace", () => {
+    expect(extractNaddr(`  ${SAMPLE_NADDR}  `)).toBe(SAMPLE_NADDR);
+  });
+
+  it("extracts naddr embedded in a Formstr URL (path style)", () => {
+    expect(extractNaddr(`https://formstr.app/f/${SAMPLE_NADDR}`)).toBe(
+      SAMPLE_NADDR,
+    );
+  });
+
+  it("extracts naddr embedded in a Formstr URL (hash style)", () => {
+    expect(
+      extractNaddr(`https://formstr.app/#/forms/view/${SAMPLE_NADDR}`),
+    ).toBe(SAMPLE_NADDR);
+  });
+
+  it("returns null for empty input", () => {
+    expect(extractNaddr("")).toBeNull();
+    expect(extractNaddr("   ")).toBeNull();
+  });
+
+  it("returns null when no naddr is present", () => {
+    expect(extractNaddr("https://formstr.app/")).toBeNull();
+    expect(extractNaddr("not a form url")).toBeNull();
+  });
+
+  it("returns null when the naddr-shaped string fails to decode", () => {
+    expect(extractNaddr("naddr1abcdefghijklmnop")).toBeNull();
+  });
+});
+
+describe("extractViewKey", () => {
+  it("returns undefined when there is no view key", () => {
+    expect(extractViewKey(SAMPLE_NADDR)).toBeUndefined();
+    expect(
+      extractViewKey(`https://formstr.app/f/${SAMPLE_NADDR}`),
+    ).toBeUndefined();
+  });
+
+  it("reads ?viewKey query param", () => {
+    expect(
+      extractViewKey(
+        `https://formstr.app/f/${SAMPLE_NADDR}?viewKey=${SAMPLE_VIEW_KEY}`,
+      ),
+    ).toBe(SAMPLE_VIEW_KEY);
+  });
+
+  it("reads &viewKey when not the first param", () => {
+    expect(
+      extractViewKey(
+        `https://formstr.app/f/${SAMPLE_NADDR}?foo=bar&viewKey=${SAMPLE_VIEW_KEY}`,
+      ),
+    ).toBe(SAMPLE_VIEW_KEY);
+  });
+
+  it("decodes percent-encoded keys", () => {
+    expect(
+      extractViewKey(
+        `https://formstr.app/f/${SAMPLE_NADDR}?viewKey=a%2Fb`,
+      ),
+    ).toBe("a/b");
+  });
+
+  it("ignores responseKey query param (admin secret must not propagate)", () => {
+    expect(
+      extractViewKey(
+        `https://formstr.app/f/${SAMPLE_NADDR}?responseKey=should-be-ignored`,
+      ),
+    ).toBeUndefined();
+  });
+
+  it("ignores path-style trailing segments", () => {
+    // Pre-rename code accidentally extracted `<naddr>/<segment>` as a key.
+    // We now only honor the explicit `?viewKey=` query form.
+    expect(
+      extractViewKey(`https://formstr.app/forms/${SAMPLE_NADDR}/some-segment`),
+    ).toBeUndefined();
+  });
+});
+
+describe("parseFormInput", () => {
+  it("returns canonical attachment for a bare naddr", () => {
+    expect(parseFormInput(SAMPLE_NADDR)).toEqual({ naddr: SAMPLE_NADDR });
+  });
+
+  it("preserves viewKey when present", () => {
+    const parsed = parseFormInput(
+      `https://formstr.app/f/${SAMPLE_NADDR}?viewKey=${SAMPLE_VIEW_KEY}`,
+    );
+    expect(parsed).toEqual({
+      naddr: SAMPLE_NADDR,
+      viewKey: SAMPLE_VIEW_KEY,
+    });
+  });
+
+  it("does not propagate responseKey", () => {
+    const parsed = parseFormInput(
+      `https://formstr.app/f/${SAMPLE_NADDR}?responseKey=admin-secret`,
+    );
+    expect(parsed).toEqual({ naddr: SAMPLE_NADDR });
+  });
+
+  it("returns null for invalid input", () => {
+    expect(parseFormInput("nope")).toBeNull();
+    expect(parseFormInput("")).toBeNull();
+  });
+});
+
+describe("buildFormstrUrl", () => {
+  it("builds a base URL when no view key", () => {
+    expect(buildFormstrUrl({ naddr: SAMPLE_NADDR })).toBe(
+      `https://formstr.app/f/${SAMPLE_NADDR}`,
+    );
+  });
+
+  it("appends viewKey as query param", () => {
+    expect(
+      buildFormstrUrl({ naddr: SAMPLE_NADDR, viewKey: "a/b" }),
+    ).toBe(`https://formstr.app/f/${SAMPLE_NADDR}?viewKey=a%2Fb`);
+  });
+});

--- a/src/utils/formLink.ts
+++ b/src/utils/formLink.ts
@@ -68,7 +68,7 @@ export function extractViewKey(input: string): string | undefined {
   if (!input) return undefined;
   const match = input.trim().match(VIEW_KEY_REGEX);
   if (!match?.[1]) return undefined;
-  return decodeURIComponent(match[1]);
+  return decodeURIComponent(match[1]).toLowerCase();
 }
 
 /**

--- a/src/utils/formLink.ts
+++ b/src/utils/formLink.ts
@@ -1,0 +1,98 @@
+import { nip19 } from "nostr-tools";
+import type { IFormAttachment } from "./types";
+
+/**
+ * Helpers for converting between user-supplied form references
+ * (raw `naddr1...` strings or Formstr URLs) and the canonical
+ * `IFormAttachment` shape stored on a calendar event.
+ *
+ * IMPORTANT — viewKey vs. responseKey
+ *
+ * Formstr distinguishes two secrets per encrypted form:
+ *
+ *   • viewKey      — a read-only NIP-44 decryption key, surfaced in
+ *                    shareable links as `?viewKey=<hex>`. Safe to embed
+ *                    in a calendar event so recipients can decrypt and
+ *                    fill the form.
+ *
+ *   • responseKey  — the form *owner's* admin / edit key. Possessing
+ *                    it allows modifying the form definition itself,
+ *                    so it must NEVER be embedded in a calendar event
+ *                    or any user-shared artifact.
+ *
+ * This module only ever extracts and persists viewKey. If a URL accidentally
+ * contains a `responseKey=` query param it is ignored.
+ */
+
+const NADDR_REGEX = /naddr1[0-9a-z]+/i;
+const VIEW_KEY_REGEX = /[?&]viewKey=([^&#\s]+)/i;
+
+/**
+ * Extracts an `naddr` from arbitrary user input.
+ *
+ * Accepts:
+ *  - bare `naddr1...`
+ *  - Formstr URLs (any path/hash/query variant) containing an `naddr1...`
+ *  - leading/trailing whitespace
+ *
+ * Returns the lowercased naddr if it decodes to a valid Nostr address,
+ * otherwise null.
+ */
+export function extractNaddr(input: string): string | null {
+  if (!input) return null;
+  const match = input.trim().match(NADDR_REGEX);
+  if (!match) return null;
+  const candidate = match[0].toLowerCase();
+  try {
+    const decoded = nip19.decode(candidate);
+    if (decoded.type !== "naddr") return null;
+    return candidate;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Extracts the optional `viewKey` query parameter from a Formstr URL.
+ *
+ * Only the `?viewKey=<value>` query form is recognized — this matches
+ * Formstr's canonical share-link format, e.g.
+ *
+ *   https://formstr.app/f/naddr1...?viewKey=4155adc1f08a7c0d...
+ *
+ * Returns undefined when the input contains no viewKey. Any
+ * `responseKey=` parameter is intentionally ignored, as it represents
+ * the form owner's admin secret and must not propagate.
+ */
+export function extractViewKey(input: string): string | undefined {
+  if (!input) return undefined;
+  const match = input.trim().match(VIEW_KEY_REGEX);
+  if (!match?.[1]) return undefined;
+  return decodeURIComponent(match[1]);
+}
+
+/**
+ * Parses a user-supplied string (naddr or Formstr URL) into a
+ * canonical IFormAttachment. Returns null if no valid naddr is found.
+ */
+export function parseFormInput(input: string): IFormAttachment | null {
+  const naddr = extractNaddr(input);
+  if (!naddr) return null;
+  const viewKey = extractViewKey(input);
+  return viewKey ? { naddr, viewKey } : { naddr };
+}
+
+/**
+ * Builds a canonical Formstr URL for a given form attachment.
+ * Used for "open in Formstr" links.
+ *
+ * Path style is `https://formstr.app/f/<naddr>` because that is the
+ * variant currently exposed by Formstr's public web app at the time of
+ * writing. If the attachment carries a viewKey it is appended as the
+ * `viewKey` query parameter, matching Formstr's own share-link format.
+ */
+export function buildFormstrUrl(form: IFormAttachment): string {
+  const base = `https://formstr.app/f/${form.naddr}`;
+  if (!form.viewKey) return base;
+  return `${base}?viewKey=${encodeURIComponent(form.viewKey)}`;
+}

--- a/src/utils/parser.test.ts
+++ b/src/utils/parser.test.ts
@@ -153,7 +153,9 @@ describe("nostrEventToCalendar", () => {
       ],
     });
     const result = nostrEventToCalendar(event);
-    expect(result.repeat.rrule).toBe("FREQ=DAILY;COUNT=5;UNTIL=20250430T100000Z");
+    expect(result.repeat.rrule).toBe(
+      "FREQ=DAILY;COUNT=5;UNTIL=20250430T100000Z",
+    );
   });
 
   it("sets repeat.rrule to null for non-recurring events", () => {
@@ -233,5 +235,50 @@ describe("nostrEventToCalendar", () => {
     expect(result.reference).toEqual(["https://nostr.com"]);
     expect(result.image).toBe("https://img.com/pic.png");
     expect(result.repeat.rrule).toBe("FREQ=DAILY");
+  });
+});
+
+describe("nostrEventToCalendar form tags", () => {
+  it("returns undefined forms when no form tag is present", () => {
+    const result = nostrEventToCalendar(makeNostrEvent());
+    expect(result.forms).toBeUndefined();
+  });
+
+  it("parses a form tag with naddr only", () => {
+    const result = nostrEventToCalendar(
+      makeNostrEvent({ tags: [["form", "naddr1abc"]] }),
+    );
+    expect(result.forms).toEqual([{ naddr: "naddr1abc" }]);
+  });
+
+  it("parses a form tag with naddr and viewKey", () => {
+    const result = nostrEventToCalendar(
+      makeNostrEvent({ tags: [["form", "naddr1abc", "key-1"]] }),
+    );
+    expect(result.forms).toEqual([
+      { naddr: "naddr1abc", viewKey: "key-1" },
+    ]);
+  });
+
+  it("parses multiple form tags", () => {
+    const result = nostrEventToCalendar(
+      makeNostrEvent({
+        tags: [
+          ["form", "naddr1aaa"],
+          ["form", "naddr1bbb", "k2"],
+        ],
+      }),
+    );
+    expect(result.forms).toEqual([
+      { naddr: "naddr1aaa" },
+      { naddr: "naddr1bbb", viewKey: "k2" },
+    ]);
+  });
+
+  it("ignores empty-value form tags", () => {
+    const result = nostrEventToCalendar(
+      makeNostrEvent({ tags: [["form", ""]] }),
+    );
+    expect(result.forms).toBeUndefined();
   });
 });

--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -74,6 +74,16 @@ export const nostrEventToCalendar = (
           parsedEvent.notificationPreference = value;
         }
         break;
+      case "form":
+        if (value) {
+          const viewKey = event.tags[index]?.[2];
+          if (!parsedEvent.forms) parsedEvent.forms = [];
+          parsedEvent.forms.push({
+            naddr: value,
+            ...(viewKey ? { viewKey } : {}),
+          });
+        }
+        break;
       case "L":
         switch (value) {
           case "rrule":

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -35,6 +35,25 @@ export interface IScheduledNotification {
 
 export type NotificationPreference = "enabled" | "disabled";
 
+/**
+ * Reference to a Formstr form attached to a calendar event.
+ *
+ * Stored on a private calendar event as a `form` tag:
+ *   ["form", naddr, viewKey?]
+ *
+ * The naddr is the Nostr address (NIP-19) of the form.
+ *
+ * The optional viewKey is the form's read-only NIP-44 decryption key —
+ * the same value Formstr surfaces in shareable links as `?viewKey=<hex>`.
+ * It must NEVER be confused with the form's `responseKey` (a.k.a. admin /
+ * edit key), which grants write access to the form definition itself and
+ * must never be embedded in shared calendar events.
+ */
+export interface IFormAttachment {
+  naddr: string;
+  viewKey?: string;
+}
+
 export interface ICalendarEvent {
   begin: number;
   description: string;
@@ -66,4 +85,11 @@ export interface ICalendarEvent {
   calendarId?: string;
   isInvitation?: boolean;
   relayHint?: string;
+  /**
+   * Forms attached to this event (Formstr).
+   * Authors may attach one or more forms; participants are expected to
+   * fill them when adding the event to their calendar.
+   * Currently only persisted for private events.
+   */
+  forms?: IFormAttachment[];
 }


### PR DESCRIPTION
Addresses #71

Add an additive 'forms' field to ICalendarEvent so authors can attach one or more Formstr forms to a private calendar event. The form is referenced by naddr with an optional opaque viewKey:

  ['form', 'naddr', 'viewKey?']

This PR is data + edit-UI only. No participant-facing or response-fetch behavior yet. Those land in subsequent PRs.

- types: add IFormAttachment and optional ICalendarEvent.forms
- parser: parse 'form' tags into ICalendarEvent.forms
- nostr: serialize form tags in preparePrivateCalendarEvent
- formLink: helper to parse user input (raw naddr or Formstr URL) into a canonical IFormAttachment, plus buildFormstrUrl
- CalendarEventEdit: 'Forms' section gated to private events, with attach/remove UI mirroring existing field patterns
- dictionary: en-US + de-DE copy for new UI strings
- tests: unit tests for formLink + form-tag parser round-trip