### PR TITLE
feat: rsvp split pr3

### DIFF
--- a/src/common/EventConfigs.ts
+++ b/src/common/EventConfigs.ts
@@ -23,4 +23,8 @@ export enum EventKinds {
 
   // Relay List (NIP-65)
   RelayList = 10002,
+
+  // Formstr / NIP-101
+  FormTemplate = 30168,
+  FormResponse = 1069,
 }

--- a/src/common/dictionary.ts
+++ b/src/common/dictionary.ts
@@ -132,7 +132,7 @@ const dictionary: NestedObject = {
       alreadySubmitted: "You've already responded to this form.",
       yourResponse: "Your response",
       responseUnavailable:
-        "We found your submission, but the answer details are still syncing from relays.",
+        "We found your submission, and we're still collecting your answers.",
       noAnswer: "No answer",
       unknownQuestion: "Question",
       submitAgain: "Submit again",
@@ -379,7 +379,7 @@ const dictionary: NestedObject = {
       alreadySubmitted: "Sie haben dieses Formular bereits beantwortet.",
       yourResponse: "Ihre Antwort",
       responseUnavailable:
-        "Wir haben Ihre Einreichung gefunden, aber die Antwortdetails werden noch von den Relays synchronisiert.",
+        "Wir haben Ihre Einreichung gefunden und sammeln noch Ihre Antworten.",
       noAnswer: "Keine Antwort",
       unknownQuestion: "Frage",
       submitAgain: "Erneut absenden",

--- a/src/common/dictionary.ts
+++ b/src/common/dictionary.ts
@@ -130,18 +130,13 @@ const dictionary: NestedObject = {
       fetchError: "Could not load the form. Please try again.",
       submitError: "Could not submit your response. Please try again.",
       alreadySubmitted: "You've already responded to this form.",
+      yourResponse: "Your response",
+      responseUnavailable:
+        "We found your submission, but the answer details are still syncing from relays.",
+      noAnswer: "No answer",
+      unknownQuestion: "Question",
       submitAgain: "Submit again",
       continue: "Continue",
-    },
-    formResponses: {
-      viewButton: "View responses",
-      title: "Form responses",
-      empty: "No one has submitted this form yet.",
-      respondent: "Respondent",
-      submittedAt: "Submitted",
-      loadError: "Could not load form responses.",
-      encryptedNotice:
-        "This form is encrypted. Open it in Formstr to view responses.",
     },
     deleteEvent: {
       title: "Delete Event",
@@ -167,6 +162,7 @@ const dictionary: NestedObject = {
       notifications: "Notifications",
       notificationsOn: "Enabled for this calendar",
       notificationsOff: "Disabled for this calendar",
+      submit: "Absenden",
       notificationsAppOnly: "Notifications are only available in the app.",
       onboardingExplanation:
         "Create a calendar to get started. Events are organized into calendars — you need at least one to add and manage your events.",
@@ -175,6 +171,11 @@ const dictionary: NestedObject = {
     sidebar: {
       calendars: "Calendars",
       noCalendarsYet: "No calendars yet",
+      yourResponse: "Ihre Antwort",
+      responseUnavailable:
+        "Wir haben Ihre Antwort gefunden, aber die Details synchronisieren noch von den Relays.",
+      noAnswer: "Keine Antwort",
+      unknownQuestion: "Frage",
       createCalendar: "Create Calendar",
     },
     addToCalendar: {
@@ -364,7 +365,6 @@ const dictionary: NestedObject = {
       fillTitle: "Formular ausfüllen",
       fillOut: "Ausfüllen",
       viewOrUpdate: "Antwort ansehen / aktualisieren",
-      submit: "Absenden",
       cancel: "Abbrechen",
       submitting: "Wird gesendet…",
       retry: "Erneut versuchen",
@@ -376,16 +376,6 @@ const dictionary: NestedObject = {
       alreadySubmitted: "Sie haben dieses Formular bereits beantwortet.",
       submitAgain: "Erneut absenden",
       continue: "Weiter",
-    },
-    formResponses: {
-      viewButton: "Antworten ansehen",
-      title: "Formularantworten",
-      empty: "Noch hat niemand auf dieses Formular geantwortet.",
-      respondent: "Antwortende(r)",
-      submittedAt: "Gesendet",
-      loadError: "Antworten konnten nicht geladen werden.",
-      encryptedNotice:
-        "Dieses Formular ist verschlüsselt. Öffnen Sie es in Formstr, um die Antworten zu sehen.",
     },
     deleteEvent: {
       title: "Termin löschen",

--- a/src/common/dictionary.ts
+++ b/src/common/dictionary.ts
@@ -138,6 +138,9 @@ const dictionary: NestedObject = {
       submitAgain: "Submit again",
       continue: "Continue",
     },
+    formResponses: {
+      viewButton: "View responses in Formstr",
+    },
     deleteEvent: {
       title: "Delete Event",
       deleteForEveryone: "Delete for all participants",
@@ -374,8 +377,16 @@ const dictionary: NestedObject = {
       submitError:
         "Ihre Antwort konnte nicht gesendet werden. Bitte versuchen Sie es erneut.",
       alreadySubmitted: "Sie haben dieses Formular bereits beantwortet.",
+      yourResponse: "Ihre Antwort",
+      responseUnavailable:
+        "Wir haben Ihre Einreichung gefunden, aber die Antwortdetails werden noch von den Relays synchronisiert.",
+      noAnswer: "Keine Antwort",
+      unknownQuestion: "Frage",
       submitAgain: "Erneut absenden",
       continue: "Weiter",
+    },
+    formResponses: {
+      viewButton: "Antworten in Formstr ansehen",
     },
     deleteEvent: {
       title: "Termin löschen",

--- a/src/common/fetchUserFormResponse.test.ts
+++ b/src/common/fetchUserFormResponse.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 
 // Mock heavy deps before importing fetchUserFormResponse — nostr.ts imports
 // many runtime modules we don't want to execute in this test.
-const { mockQuerySync } = vi.hoisted(() => ({ mockQuerySync: vi.fn() }));
+const { mockQuerySync, mockRelayStore } = vi.hoisted(() => ({
+  mockQuerySync: vi.fn(),
+  mockRelayStore: { relays: [] as string[] },
+}));
 vi.mock("./nostrRuntime", () => ({
   nostrRuntime: {
     querySync: mockQuerySync,
@@ -18,7 +21,7 @@ vi.mock("./signer", () => ({
   },
 }));
 vi.mock("../stores/relays", () => ({
-  useRelayStore: { getState: () => ({ relays: [] }) },
+  useRelayStore: { getState: () => mockRelayStore },
 }));
 vi.mock("../stores/calendarLists", () => ({ useCalendarLists: {} }));
 vi.mock("../stores/eventDetails", () => ({ TEMP_CALENDAR_ID: "tmp" }));
@@ -42,6 +45,7 @@ const make = (id: string, ts: number) => ({
 describe("fetchUserFormResponse", () => {
   beforeEach(() => {
     mockQuerySync.mockReset();
+    mockRelayStore.relays = [];
   });
 
   it("returns null when relays return no events", async () => {
@@ -77,9 +81,18 @@ describe("fetchUserFormResponse", () => {
     ]);
     const [relays] = mockQuerySync.mock.calls[0];
     const xCount = (relays as string[]).filter(
-      (r) => r === "wss://relay.damus.io",
+      (r) => r === "wss://relay.damus.io/",
     ).length;
     expect(xCount).toBe(1);
-    expect(relays).toContain("wss://relay.x");
+    expect(relays).toContain("wss://relay.x/");
+  });
+
+  it("includes user-configured relays for discovery", async () => {
+    mockRelayStore.relays = ["wss://relay.user"];
+    mockQuerySync.mockResolvedValue([]);
+    await fetchUserFormResponse(COORD, USER, ["wss://relay.form"]);
+    const [relays] = mockQuerySync.mock.calls[0];
+    expect(relays).toContain("wss://relay.form/");
+    expect(relays).toContain("wss://relay.user/");
   });
 });

--- a/src/common/fetchUserFormResponse.test.ts
+++ b/src/common/fetchUserFormResponse.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// Mock heavy deps before importing fetchUserFormResponse — nostr.ts imports
+// many runtime modules we don't want to execute in this test.
+const { mockQuerySync } = vi.hoisted(() => ({ mockQuerySync: vi.fn() }));
+vi.mock("./nostrRuntime", () => ({
+  nostrRuntime: {
+    querySync: mockQuerySync,
+    subscribe: vi.fn(),
+    fetchOne: vi.fn(),
+    addEvent: vi.fn(),
+  },
+}));
+vi.mock("./signer", () => ({
+  signerManager: {
+    getSigner: vi.fn(),
+    getSignerRelays: vi.fn().mockResolvedValue([]),
+  },
+}));
+vi.mock("../stores/relays", () => ({
+  useRelayStore: { getState: () => ({ relays: [] }) },
+}));
+vi.mock("../stores/calendarLists", () => ({ useCalendarLists: {} }));
+vi.mock("../stores/eventDetails", () => ({ TEMP_CALENDAR_ID: "tmp" }));
+vi.mock("../stores/events", () => ({}));
+
+import { fetchUserFormResponse } from "./nostr";
+
+const COORD = "30168:abcd:demo";
+const USER = "e".repeat(64);
+
+const make = (id: string, ts: number) => ({
+  id,
+  pubkey: USER,
+  kind: 1069,
+  created_at: ts,
+  tags: [["a", COORD]],
+  content: "",
+  sig: "",
+});
+
+describe("fetchUserFormResponse", () => {
+  beforeEach(() => {
+    mockQuerySync.mockReset();
+  });
+
+  it("returns null when relays return no events", async () => {
+    mockQuerySync.mockResolvedValue([]);
+    const result = await fetchUserFormResponse(COORD, USER);
+    expect(result).toBeNull();
+  });
+
+  it("returns the latest response by created_at", async () => {
+    const older = make("a", 100);
+    const newer = make("b", 200);
+    mockQuerySync.mockResolvedValue([older, newer]);
+    const result = await fetchUserFormResponse(COORD, USER);
+    expect(result?.id).toBe("b");
+  });
+
+  it("queries with correct filter (kind/authors/#a)", async () => {
+    mockQuerySync.mockResolvedValue([]);
+    await fetchUserFormResponse(COORD, USER, ["wss://relay.x"]);
+    const [, filter] = mockQuerySync.mock.calls[0];
+    expect(filter).toMatchObject({
+      kinds: [1069],
+      authors: [USER],
+      "#a": [COORD],
+    });
+  });
+
+  it("merges defaultRelays with extraRelays without duplicates", async () => {
+    mockQuerySync.mockResolvedValue([]);
+    await fetchUserFormResponse(COORD, USER, [
+      "wss://relay.damus.io", // also in defaults
+      "wss://relay.x",
+    ]);
+    const [relays] = mockQuerySync.mock.calls[0];
+    const xCount = (relays as string[]).filter(
+      (r) => r === "wss://relay.damus.io",
+    ).length;
+    expect(xCount).toBe(1);
+    expect(relays).toContain("wss://relay.x");
+  });
+});

--- a/src/common/nostr.ts
+++ b/src/common/nostr.ts
@@ -789,3 +789,35 @@ export const publishRelayList = async (relays: string[]): Promise<void> => {
   const allRelays = [...new Set([...relays, ...defaultRelays])];
   await publishToRelays(fullEvent, () => {}, allRelays);
 };
+
+/**
+ * Looks up the most recent NIP-101 form response (kind 1069) authored by
+ * `userPubkey` for the form addressed by `formCoordinate`
+ * (`30168:<form_pubkey>:<dtag>`).
+ *
+ * Returns the latest matching response event, or null if none exist on
+ * the queried relays.
+ *
+ * `extraRelays` lets callers pass relay hints embedded in the form's
+ * naddr so the lookup reaches the same relays the form lives on.
+ *
+ * Note: this is the canonical "has the user submitted?" check. UI must
+ * not infer submission status from local memory across reloads.
+ */
+export const fetchUserFormResponse = async (
+  formCoordinate: string,
+  userPubkey: string,
+  extraRelays: string[] = [],
+): Promise<Event | null> => {
+  const relays = [...new Set([...defaultRelays, ...extraRelays])];
+  const events = await nostrRuntime.querySync(relays, {
+    kinds: [EventKinds.FormResponse],
+    authors: [userPubkey],
+    "#a": [formCoordinate],
+    limit: 1,
+  });
+  if (!events || events.length === 0) return null;
+  return events.reduce((latest, current) =>
+    current.created_at > latest.created_at ? current : latest,
+  );
+};

--- a/src/common/nostr.ts
+++ b/src/common/nostr.ts
@@ -52,6 +52,26 @@ export const getRelays = (): string[] => {
   return userRelays.length > 0 ? userRelays : defaultRelays;
 };
 
+const normalizeRelayList = (relays: string[]): string[] => {
+  const normalized = new Set<string>();
+  relays.forEach((url) => {
+    try {
+      normalized.add(normalizeURL(url));
+    } catch {
+      // Ignore malformed relay hints from external naddr/form links.
+    }
+  });
+  return [...normalized];
+};
+
+const getDiscoveryRelays = (hintRelays: string[] = []): string[] => {
+  return normalizeRelayList([
+    ...hintRelays,
+    ...defaultRelays,
+    ...useRelayStore.getState().relays,
+  ]);
+};
+
 export async function getUserPublicKey() {
   const signer = await signerManager.getSigner();
   const pubKey = await signer.getPublicKey();
@@ -69,31 +89,23 @@ export const ensureRelay = async (
   return relay;
 };
 
-export async function publishPrivateRSVPEvent({
-  authorpubKey, // Public key of the event author
-  eventId, // The dtag of the event
-  status, // Status of the RSVP event
-  participants, // List of participant public keys
-  referenceKind,
-}: {
-  eventId: string;
+export async function publishPrivateRSVPEvent(params: {
   authorpubKey: string;
+  eventId: string;
   status: string;
   participants: string[];
   referenceKind: EventKinds.PrivateCalendarEvent;
 }) {
+  void params;
   // this function is noop
 }
 
-export async function publishPublicRSVPEvent({
-  authorpubKey,
-  eventId,
-  status,
-}: {
+export async function publishPublicRSVPEvent(params: {
   authorpubKey: string;
   eventId: string;
   status: string;
 }) {
+  void params;
   // this function is noop
 }
 
@@ -229,7 +241,6 @@ export async function publishPrivateCalendarEvent(event: ICalendarEvent) {
   await Promise.all(
     giftWraps.map(async ({ giftWrap, participant }) => {
       const relays = participantRelayMap.get(participant) ?? defaultRelays;
-      console.log(`Publishing invitation for ${participant} to ${relays}`);
       await publishToRelays(giftWrap, undefined, relays);
     }),
   );
@@ -714,11 +725,8 @@ export const fetchCalendarEvent = async (
   naddr: NAddr,
 ): Promise<{ event: Event; relayHint: string }> => {
   const { data } = decode(naddr as NAddr);
-  // Merge: naddr hints first (where the author published), then defaults as
-  // fallback.  Trusting only naddr relays is fragile: a single unavailable
-  // relay makes the event invisible to every viewer who uses a shared link.
   const hintRelays = data.relays ?? [];
-  const relays = [...new Set([...hintRelays, ...defaultRelays])];
+  const relays = getDiscoveryRelays(hintRelays);
   const filter: Filter = {
     "#d": [data.identifier],
     kinds: [data.kind],
@@ -817,7 +825,7 @@ export const fetchUserFormResponse = async (
   userPubkey: string,
   extraRelays: string[] = [],
 ): Promise<Event | null> => {
-  const relays = [...new Set([...defaultRelays, ...extraRelays])];
+  const relays = getDiscoveryRelays(extraRelays);
   const events = await nostrRuntime.querySync(relays, {
     kinds: [EventKinds.FormResponse],
     authors: [userPubkey],

--- a/src/common/nostr.ts
+++ b/src/common/nostr.ts
@@ -265,10 +265,14 @@ export async function editPrivateCalendarEvent(
   await publishToRelays(signedEvent);
 
   const eventCoordinate = `${eventKind}:${userPublicKey}:${dTag}`;
+  // Preserve the relay hint from the existing event so the updated ref still
+  // points to the relay where the event lives.  Without this the relay URL is
+  // dropped on every edit, making subsequent fetches miss the event.
   const eventRef = buildEventRef({
     kind: eventKind,
     authorPubkey: userPublicKey,
     eventDTag: dTag,
+    relayUrl: event.relayHint ?? "",
     viewKey: nip19.nsecEncode(viewSecretKey),
   });
 
@@ -710,7 +714,11 @@ export const fetchCalendarEvent = async (
   naddr: NAddr,
 ): Promise<{ event: Event; relayHint: string }> => {
   const { data } = decode(naddr as NAddr);
-  const relays = data.relays ?? defaultRelays;
+  // Merge: naddr hints first (where the author published), then defaults as
+  // fallback.  Trusting only naddr relays is fragile: a single unavailable
+  // relay makes the event invisible to every viewer who uses a shared link.
+  const hintRelays = data.relays ?? [];
+  const relays = [...new Set([...hintRelays, ...defaultRelays])];
   const filter: Filter = {
     "#d": [data.identifier],
     kinds: [data.kind],

--- a/src/common/nostr.ts
+++ b/src/common/nostr.ts
@@ -65,6 +65,10 @@ const normalizeRelayList = (relays: string[]): string[] => {
 };
 
 const getDiscoveryRelays = (hintRelays: string[] = []): string[] => {
+  // Query/discovery only: merge hints with broad fallback relays so fetches
+  // survive stale or incomplete naddr relay hints. Do not reuse this helper
+  // for publishing, where explicit relay targets must not be expanded to the
+  // public default relay set.
   return normalizeRelayList([
     ...hintRelays,
     ...defaultRelays,

--- a/src/components/AddToCalendarDialog.tsx
+++ b/src/components/AddToCalendarDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   Dialog,
   DialogTitle,
@@ -23,6 +23,7 @@ interface AddToCalendarDialogProps {
   onClose: () => void;
   event: ICalendarEvent;
   onAccept: (calendarId: string) => void;
+  initialCalendarId?: string;
 }
 
 export function AddToCalendarDialog({
@@ -30,14 +31,21 @@ export function AddToCalendarDialog({
   onClose,
   event,
   onAccept,
+  initialCalendarId,
 }: AddToCalendarDialogProps) {
   const intl = useIntl();
   const { calendars } = useCalendarLists();
   const [selectedCalendarId, setSelectedCalendarId] = useState(
-    calendars[0]?.id || "",
+    initialCalendarId || calendars[0]?.id || "",
   );
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
+
+  useEffect(() => {
+    if (!selectedCalendarId && calendars[0]?.id) {
+      setSelectedCalendarId(initialCalendarId || calendars[0].id);
+    }
+  }, [calendars, initialCalendarId, selectedCalendarId]);
 
   const handleAccept = () => {
     if (selectedCalendarId) {

--- a/src/components/AddToCalendarDialog.tsx
+++ b/src/components/AddToCalendarDialog.tsx
@@ -23,7 +23,7 @@ interface AddToCalendarDialogProps {
   onClose: () => void;
   event: ICalendarEvent;
   onAccept: (calendarId: string) => void;
-  initialCalendarId?: string;
+  defaultCalendarId?: string;
 }
 
 export function AddToCalendarDialog({
@@ -31,21 +31,21 @@ export function AddToCalendarDialog({
   onClose,
   event,
   onAccept,
-  initialCalendarId,
+  defaultCalendarId,
 }: AddToCalendarDialogProps) {
   const intl = useIntl();
   const { calendars } = useCalendarLists();
   const [selectedCalendarId, setSelectedCalendarId] = useState(
-    initialCalendarId || calendars[0]?.id || "",
+    defaultCalendarId || calendars[0]?.id || "",
   );
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
 
   useEffect(() => {
     if (!selectedCalendarId && calendars[0]?.id) {
-      setSelectedCalendarId(initialCalendarId || calendars[0].id);
+      setSelectedCalendarId(defaultCalendarId || calendars[0].id);
     }
-  }, [calendars, initialCalendarId, selectedCalendarId]);
+  }, [calendars, defaultCalendarId, selectedCalendarId]);
 
   const handleAccept = () => {
     if (selectedCalendarId) {

--- a/src/components/CalendarEvent.tsx
+++ b/src/components/CalendarEvent.tsx
@@ -60,6 +60,8 @@ import { bytesToHex } from "nostr-tools/utils";
 import { FormstrSDK } from "@formstr/sdk";
 import { FormFillerDialog } from "./FormFillerDialog";
 import type { IFormAttachment } from "../utils/types";
+import { useFormSubmissionStatus } from "../hooks/useFormSubmissionStatus";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 
 interface CalendarEventCardProps {
   event: PositionedEvent;
@@ -486,15 +488,15 @@ export function CalendarEvent({ event }: CalendarEventViewProps) {
               <Typography variant="subtitle1">
                 {intl.formatMessage({ id: "form.attachments" })}
               </Typography>
-              <Stack spacing={1}>
-                {event.forms.map((attachment) => (
-                  <FormAttachmentRow
-                    key={attachment.naddr}
-                    attachment={attachment}
-                    onFill={setActiveForm}
-                  />
-                ))}
-              </Stack>
+                <Stack spacing={1}>
+                  {event.forms.map((attachment) => (
+                    <FormAttachmentRow
+                      key={attachment.naddr}
+                      attachment={attachment}
+                      onFill={setActiveForm}
+                    />
+                  ))}
+                </Stack>
               <Divider />
             </>
           )}
@@ -548,7 +550,10 @@ function FormAttachmentRow({
   onFill: (attachment: IFormAttachment) => void;
 }) {
   const intl = useIntl();
+  const { user } = useUser();
   const [title, setTitle] = useState<string | null>(null);
+  const { status } = useFormSubmissionStatus(attachment.naddr, user?.pubkey);
+  const submitted = status.state === "submitted";
 
   useEffect(() => {
     let cancelled = false;
@@ -588,11 +593,14 @@ function FormAttachmentRow({
   return (
     <Box display="flex" alignItems="center" gap={1} flexWrap="wrap">
       <Button
-        variant="outlined"
+        variant={submitted ? "text" : "outlined"}
         size="small"
         onClick={() => onFill(attachment)}
+        startIcon={submitted ? <CheckCircleIcon color="success" /> : undefined}
       >
-        {intl.formatMessage({ id: "form.fillOut" })}
+        {intl.formatMessage({
+          id: submitted ? "form.viewOrUpdate" : "form.fillOut",
+        })}
       </Button>
       <Typography
         variant="caption"

--- a/src/components/CalendarEvent.tsx
+++ b/src/components/CalendarEvent.tsx
@@ -24,7 +24,7 @@ import {
 import { ICalendarEvent } from "../utils/types";
 import { PositionedEvent } from "../common/calendarEngine";
 import { TimeRenderer } from "./TimeRenderer";
-import { useState, useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Participant } from "./Participant";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -49,6 +49,7 @@ import { useUser } from "../stores/user";
 import { DeleteEventDialog } from "./DeleteEventDialog";
 import { CalendarListSelect } from "./CalendarListSelect";
 import { useInvitations } from "../stores/invitations";
+import { useAcceptWithFormsFlow } from "../hooks/useAcceptWithFormsFlow";
 import {
   buildEventRef,
   getCalendarEventCoordinate,
@@ -596,11 +597,6 @@ function InvitationAcceptBar({ event }: { event: ICalendarEvent }) {
   const [creatingGuest, setCreatingGuest] = useState(false);
   const [errorOpen, setErrorOpen] = useState(false);
   const [successDialogOpen, setSuccessDialogOpen] = useState(false);
-  const [pendingFormAccept, setPendingFormAccept] = useState<{
-    calendarId: string;
-    giftWrapId?: string;
-    formIndex: number;
-  } | null>(null);
 
   // Sync selected calendar once calendars load (e.g. right after login)
   useEffect(() => {
@@ -617,26 +613,46 @@ function InvitationAcceptBar({ event }: { event: ICalendarEvent }) {
     }
   }, [user, calendarsLoaded, fetchCalendars]);
 
-  const finalizeAccept = async (calendarId: string, giftWrapId?: string) => {
-    if (giftWrapId) {
-      await acceptInvitation(giftWrapId, calendarId);
-    } else {
-      const eventRef = buildEventRef({
-        kind: event.kind,
-        authorPubkey: event.user,
-        eventDTag: event.id,
-        relayUrl: event.relayHint ?? "",
-        viewKey: event.viewKey || "",
-      });
-      await addEventToCalendar(calendarId, eventRef);
-      updateEvent({
-        ...event,
-        calendarId,
-        isInvitation: false,
-      });
-    }
-    setSuccessDialogOpen(true);
-  };
+  const finalizeAccept = useCallback(
+    async ({
+      calendarId,
+      giftWrapId,
+    }: {
+      calendarId: string;
+      giftWrapId?: string;
+    }) => {
+      if (giftWrapId) {
+        await acceptInvitation(giftWrapId, calendarId);
+      } else {
+        const eventRef = buildEventRef({
+          kind: event.kind,
+          authorPubkey: event.user,
+          eventDTag: event.id,
+          relayUrl: event.relayHint ?? "",
+          viewKey: event.viewKey || "",
+        });
+        await addEventToCalendar(calendarId, eventRef);
+        updateEvent({
+          ...event,
+          calendarId,
+          isInvitation: false,
+        });
+      }
+      setSuccessDialogOpen(true);
+    },
+    [acceptInvitation, addEventToCalendar, event, updateEvent],
+  );
+
+  const {
+    pendingAccept,
+    pendingForm,
+    formCount,
+    startAccept,
+    advanceAccept,
+    cancelAccept,
+  } = useAcceptWithFormsFlow<void>({
+    onFinalize: finalizeAccept,
+  });
 
   const handleAccept = async () => {
     if (!selectedCalendarId) return;
@@ -645,16 +661,12 @@ function InvitationAcceptBar({ event }: { event: ICalendarEvent }) {
       const matchingInvitation = invitations.find(
         (inv) => inv.eventId === event.id && inv.pubkey === event.user,
       );
-      const forms = event.forms ?? [];
-      if (forms.length > 0) {
-        setPendingFormAccept({
-          calendarId: selectedCalendarId,
-          giftWrapId: matchingInvitation?.giftWrapId,
-          formIndex: 0,
-        });
-        return;
-      }
-      await finalizeAccept(selectedCalendarId, matchingInvitation?.giftWrapId);
+      await startAccept({
+        calendarId: selectedCalendarId,
+        giftWrapId: matchingInvitation?.giftWrapId,
+        attachments: event.forms ?? [],
+        context: undefined,
+      });
     } catch {
       setErrorOpen(true);
     } finally {
@@ -662,20 +674,10 @@ function InvitationAcceptBar({ event }: { event: ICalendarEvent }) {
     }
   };
 
-  const advancePendingFormAccept = async () => {
-    if (!pendingFormAccept) return;
-    const forms = event.forms ?? [];
-    const next = pendingFormAccept.formIndex + 1;
-    if (next < forms.length) {
-      setPendingFormAccept({ ...pendingFormAccept, formIndex: next });
-      return;
-    }
-
-    const { calendarId, giftWrapId } = pendingFormAccept;
-    setPendingFormAccept(null);
+  const handlePendingAcceptAdvance = async () => {
     setAccepting(true);
     try {
-      await finalizeAccept(calendarId, giftWrapId);
+      await advanceAccept();
     } catch {
       setErrorOpen(true);
     } finally {
@@ -702,11 +704,6 @@ function InvitationAcceptBar({ event }: { event: ICalendarEvent }) {
     const d = dayjs(event.begin);
     navigate(`/d/${d.year()}/${d.month() + 1}/${d.date()}`);
   };
-
-  const pendingForm = pendingFormAccept
-    ? (event.forms ?? [])[pendingFormAccept.formIndex]
-    : null;
-  const formCount = event.forms?.length ?? 0;
 
   // ── Login gate ─────────────────────────────────────────────────────────────
   if (!user) {
@@ -835,15 +832,15 @@ function InvitationAcceptBar({ event }: { event: ICalendarEvent }) {
         </Box>
       </Stack>
 
-      {pendingFormAccept && pendingForm && (
+      {pendingAccept && pendingForm && (
         <FormFillerDialog
           open
           attachment={pendingForm}
-          index={pendingFormAccept.formIndex + 1}
+          index={pendingAccept.formIndex + 1}
           total={formCount}
-          onClose={() => setPendingFormAccept(null)}
+          onClose={cancelAccept}
           onSubmitted={() => {
-            void advancePendingFormAccept();
+            void handlePendingAcceptAdvance();
           }}
         />
       )}

--- a/src/components/CalendarEvent.tsx
+++ b/src/components/CalendarEvent.tsx
@@ -57,12 +57,9 @@ import { EventCalendarListManagement } from "./EventCalendarListManagement";
 import { signerManager } from "../common/signer";
 import { generateSecretKey } from "nostr-tools";
 import { bytesToHex } from "nostr-tools/utils";
-import { FormstrSDK } from "@formstr/sdk";
 import { FormFillerDialog } from "./FormFillerDialog";
-import { buildFormstrResponsesUrl } from "../utils/formLink";
+import { FormAttachmentRow } from "./FormAttachmentRow";
 import type { IFormAttachment } from "../utils/types";
-import { useFormSubmissionStatus } from "../hooks/useFormSubmissionStatus";
-import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 
 interface CalendarEventCardProps {
   event: PositionedEvent;
@@ -543,99 +540,6 @@ export function CalendarEvent({ event }: CalendarEventViewProps) {
         onClose={() => setActiveForm(null)}
         onSubmitted={() => setActiveForm(null)}
       />
-    </Box>
-  );
-}
-
-function FormAttachmentRow({
-  attachment,
-  eventAuthor,
-  onFill,
-}: {
-  attachment: IFormAttachment;
-  eventAuthor: string;
-  onFill: (attachment: IFormAttachment) => void;
-}) {
-  const intl = useIntl();
-  const { user } = useUser();
-  const [title, setTitle] = useState<string | null>(null);
-  const { status } = useFormSubmissionStatus(attachment.naddr, user?.pubkey);
-  const submitted = status.state === "submitted";
-  const hasEditAccess = !!user?.pubkey && eventAuthor === user.pubkey;
-
-  useEffect(() => {
-    let cancelled = false;
-
-    setTitle(null);
-
-    const resolveTitle = async () => {
-      try {
-        const sdk = new FormstrSDK();
-        const form = (await (attachment.viewKey
-          ? sdk.fetchFormWithViewKey(attachment.naddr, attachment.viewKey)
-          : sdk.fetchForm(attachment.naddr))) as { name?: string };
-        const nextTitle = form.name?.trim();
-
-        if (!cancelled) {
-          setTitle(nextTitle || null);
-        }
-      } catch {
-        if (!cancelled) {
-          setTitle(null);
-        }
-      }
-    };
-
-    void resolveTitle();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [attachment.naddr, attachment.viewKey]);
-
-  const fallbackLabel =
-    attachment.naddr.length > 24
-      ? `${attachment.naddr.slice(0, 12)}…${attachment.naddr.slice(-8)}`
-      : attachment.naddr;
-
-  return (
-    <Box display="flex" alignItems="center" gap={1} flexWrap="wrap">
-      <Button
-        variant={submitted ? "text" : "outlined"}
-        size="small"
-        onClick={() => onFill(attachment)}
-        startIcon={submitted ? <CheckCircleIcon color="success" /> : undefined}
-      >
-        {intl.formatMessage({
-          id: submitted ? "form.viewOrUpdate" : "form.fillOut",
-        })}
-      </Button>
-      {hasEditAccess && (
-        <Button
-          variant="text"
-          size="small"
-          href={buildFormstrResponsesUrl(attachment)}
-          target="_blank"
-          rel="noopener noreferrer"
-          endIcon={<OpenInNew fontSize="inherit" />}
-        >
-          {intl.formatMessage({ id: "formResponses.viewButton" })}
-        </Button>
-      )}
-      <Typography
-        variant="caption"
-        color="text.secondary"
-        sx={
-          title
-            ? { wordBreak: "break-word" }
-            : {
-                fontFamily: "monospace",
-                wordBreak: "break-all",
-              }
-        }
-      >
-        {title ?? fallbackLabel}
-      </Typography>
     </Box>
   );
 }

--- a/src/components/CalendarEvent.tsx
+++ b/src/components/CalendarEvent.tsx
@@ -462,7 +462,9 @@ export function CalendarEvent({ event }: CalendarEventViewProps) {
               <Typography variant="subtitle1">
                 {intl.formatMessage({ id: "navigation.description" })}
               </Typography>
-              <Typography variant="body2">
+              {/* component="div" avoids <p> nesting: Typography defaults to <p>
+                  but react-markdown also wraps paragraphs in <p> tags */}
+              <Typography component="div" variant="body2">
                 <Markdown remarkPlugins={[remarkGfm]}>
                   {event.description}
                 </Markdown>
@@ -708,6 +710,9 @@ function InvitationAcceptBar({ event }: { event: ICalendarEvent }) {
           kind: event.kind,
           authorPubkey: event.user,
           eventDTag: event.id,
+          // Preserve the relay hint so re-fetching this event from the
+          // calendar list after a page reload actually finds it.
+          relayUrl: event.relayHint ?? "",
           viewKey: event.viewKey || "",
         });
         await addEventToCalendar(selectedCalendarId, eventRef);

--- a/src/components/CalendarEvent.tsx
+++ b/src/components/CalendarEvent.tsx
@@ -59,6 +59,7 @@ import { generateSecretKey } from "nostr-tools";
 import { bytesToHex } from "nostr-tools/utils";
 import { FormstrSDK } from "@formstr/sdk";
 import { FormFillerDialog } from "./FormFillerDialog";
+import { buildFormstrResponsesUrl } from "../utils/formLink";
 import type { IFormAttachment } from "../utils/types";
 import { useFormSubmissionStatus } from "../hooks/useFormSubmissionStatus";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
@@ -491,15 +492,16 @@ export function CalendarEvent({ event }: CalendarEventViewProps) {
               <Typography variant="subtitle1">
                 {intl.formatMessage({ id: "form.attachments" })}
               </Typography>
-                <Stack spacing={1}>
-                  {event.forms.map((attachment) => (
-                    <FormAttachmentRow
-                      key={attachment.naddr}
-                      attachment={attachment}
-                      onFill={setActiveForm}
-                    />
-                  ))}
-                </Stack>
+              <Stack spacing={1}>
+                {event.forms.map((attachment) => (
+                  <FormAttachmentRow
+                    key={attachment.naddr}
+                    attachment={attachment}
+                    eventAuthor={event.user}
+                    onFill={setActiveForm}
+                  />
+                ))}
+              </Stack>
               <Divider />
             </>
           )}
@@ -547,9 +549,11 @@ export function CalendarEvent({ event }: CalendarEventViewProps) {
 
 function FormAttachmentRow({
   attachment,
+  eventAuthor,
   onFill,
 }: {
   attachment: IFormAttachment;
+  eventAuthor: string;
   onFill: (attachment: IFormAttachment) => void;
 }) {
   const intl = useIntl();
@@ -557,6 +561,7 @@ function FormAttachmentRow({
   const [title, setTitle] = useState<string | null>(null);
   const { status } = useFormSubmissionStatus(attachment.naddr, user?.pubkey);
   const submitted = status.state === "submitted";
+  const hasEditAccess = !!user?.pubkey && eventAuthor === user.pubkey;
 
   useEffect(() => {
     let cancelled = false;
@@ -605,6 +610,18 @@ function FormAttachmentRow({
           id: submitted ? "form.viewOrUpdate" : "form.fillOut",
         })}
       </Button>
+      {hasEditAccess && (
+        <Button
+          variant="text"
+          size="small"
+          href={buildFormstrResponsesUrl(attachment)}
+          target="_blank"
+          rel="noopener noreferrer"
+          endIcon={<OpenInNew fontSize="inherit" />}
+        >
+          {intl.formatMessage({ id: "formResponses.viewButton" })}
+        </Button>
+      )}
       <Typography
         variant="caption"
         color="text.secondary"

--- a/src/components/CalendarEvent.tsx
+++ b/src/components/CalendarEvent.tsx
@@ -408,6 +408,7 @@ export function CalendarEvent({ event }: CalendarEventViewProps) {
             kind: event.kind,
             authorPubkey: event.user,
             eventDTag: event.id,
+            relayUrl: event.relayHint ?? "",
             viewKey: event.viewKey,
           })
         : undefined);
@@ -674,6 +675,11 @@ function InvitationAcceptBar({ event }: { event: ICalendarEvent }) {
   const [creatingGuest, setCreatingGuest] = useState(false);
   const [errorOpen, setErrorOpen] = useState(false);
   const [successDialogOpen, setSuccessDialogOpen] = useState(false);
+  const [pendingFormAccept, setPendingFormAccept] = useState<{
+    calendarId: string;
+    giftWrapId?: string;
+    formIndex: number;
+  } | null>(null);
 
   // Sync selected calendar once calendars load (e.g. right after login)
   useEffect(() => {
@@ -690,39 +696,65 @@ function InvitationAcceptBar({ event }: { event: ICalendarEvent }) {
     }
   }, [user, calendarsLoaded, fetchCalendars]);
 
+  const finalizeAccept = async (calendarId: string, giftWrapId?: string) => {
+    if (giftWrapId) {
+      await acceptInvitation(giftWrapId, calendarId);
+    } else {
+      const eventRef = buildEventRef({
+        kind: event.kind,
+        authorPubkey: event.user,
+        eventDTag: event.id,
+        relayUrl: event.relayHint ?? "",
+        viewKey: event.viewKey || "",
+      });
+      await addEventToCalendar(calendarId, eventRef);
+      updateEvent({
+        ...event,
+        calendarId,
+        isInvitation: false,
+      });
+    }
+    setSuccessDialogOpen(true);
+  };
+
   const handleAccept = async () => {
     if (!selectedCalendarId) return;
     setAccepting(true);
     try {
-      // If there is a matching gift-wrap invitation in the store, use the full
-      // invitation flow so the record is removed from the notifications panel.
-      // Otherwise (shared-link context) build the event reference directly.
       const matchingInvitation = invitations.find(
         (inv) => inv.eventId === event.id && inv.pubkey === event.user,
       );
-      if (matchingInvitation) {
-        await acceptInvitation(
-          matchingInvitation.giftWrapId,
-          selectedCalendarId,
-        );
-      } else {
-        const eventRef = buildEventRef({
-          kind: event.kind,
-          authorPubkey: event.user,
-          eventDTag: event.id,
-          // Preserve the relay hint so re-fetching this event from the
-          // calendar list after a page reload actually finds it.
-          relayUrl: event.relayHint ?? "",
-          viewKey: event.viewKey || "",
-        });
-        await addEventToCalendar(selectedCalendarId, eventRef);
-        updateEvent({
-          ...event,
+      const forms = event.forms ?? [];
+      if (forms.length > 0) {
+        setPendingFormAccept({
           calendarId: selectedCalendarId,
-          isInvitation: false,
+          giftWrapId: matchingInvitation?.giftWrapId,
+          formIndex: 0,
         });
+        return;
       }
-      setSuccessDialogOpen(true);
+      await finalizeAccept(selectedCalendarId, matchingInvitation?.giftWrapId);
+    } catch {
+      setErrorOpen(true);
+    } finally {
+      setAccepting(false);
+    }
+  };
+
+  const advancePendingFormAccept = async () => {
+    if (!pendingFormAccept) return;
+    const forms = event.forms ?? [];
+    const next = pendingFormAccept.formIndex + 1;
+    if (next < forms.length) {
+      setPendingFormAccept({ ...pendingFormAccept, formIndex: next });
+      return;
+    }
+
+    const { calendarId, giftWrapId } = pendingFormAccept;
+    setPendingFormAccept(null);
+    setAccepting(true);
+    try {
+      await finalizeAccept(calendarId, giftWrapId);
     } catch {
       setErrorOpen(true);
     } finally {
@@ -749,6 +781,11 @@ function InvitationAcceptBar({ event }: { event: ICalendarEvent }) {
     const d = dayjs(event.begin);
     navigate(`/d/${d.year()}/${d.month() + 1}/${d.date()}`);
   };
+
+  const pendingForm = pendingFormAccept
+    ? (event.forms ?? [])[pendingFormAccept.formIndex]
+    : null;
+  const formCount = event.forms?.length ?? 0;
 
   // ── Login gate ─────────────────────────────────────────────────────────────
   if (!user) {
@@ -876,6 +913,19 @@ function InvitationAcceptBar({ event }: { event: ICalendarEvent }) {
           </Button>
         </Box>
       </Stack>
+
+      {pendingFormAccept && pendingForm && (
+        <FormFillerDialog
+          open
+          attachment={pendingForm}
+          index={pendingFormAccept.formIndex + 1}
+          total={formCount}
+          onClose={() => setPendingFormAccept(null)}
+          onSubmitted={() => {
+            void advancePendingFormAccept();
+          }}
+        />
+      )}
 
       <Snackbar
         open={errorOpen}

--- a/src/components/FormAttachmentRow.tsx
+++ b/src/components/FormAttachmentRow.tsx
@@ -2,10 +2,10 @@ import { useEffect, useState } from "react";
 import { Box, Button, Typography } from "@mui/material";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
-import { FormstrSDK } from "@formstr/sdk";
 import { useIntl } from "react-intl";
 import { useUser } from "../stores/user";
 import { useFormSubmissionStatus } from "../hooks/useFormSubmissionStatus";
+import { fetchAttachedFormCached } from "../utils/formAttachment";
 import { buildFormstrResponsesUrl } from "../utils/formLink";
 import type { IFormAttachment } from "../utils/types";
 
@@ -25,6 +25,7 @@ export function FormAttachmentRow({
   const intl = useIntl();
   const { user } = useUser();
   const [title, setTitle] = useState<string | null>(null);
+  const { naddr, viewKey } = attachment;
   const { status } = useFormSubmissionStatus(
     showSubmissionStatus ? attachment.naddr : undefined,
     user?.pubkey,
@@ -40,10 +41,10 @@ export function FormAttachmentRow({
 
     const resolveTitle = async () => {
       try {
-        const sdk = new FormstrSDK();
-        const form = (await (attachment.viewKey
-          ? sdk.fetchFormWithViewKey(attachment.naddr, attachment.viewKey)
-          : sdk.fetchForm(attachment.naddr))) as { name?: string };
+        const form = await fetchAttachedFormCached<{ name?: string }>({
+          naddr,
+          viewKey,
+        });
         const nextTitle = form.name?.trim();
 
         if (!cancelled) {
@@ -61,7 +62,7 @@ export function FormAttachmentRow({
     return () => {
       cancelled = true;
     };
-  }, [attachment.naddr, attachment.viewKey]);
+  }, [naddr, viewKey]);
 
   const fallbackLabel =
     attachment.naddr.length > 24

--- a/src/components/FormAttachmentRow.tsx
+++ b/src/components/FormAttachmentRow.tsx
@@ -13,22 +13,25 @@ type FormAttachmentRowProps = {
   attachment: IFormAttachment;
   eventAuthor?: string;
   onFill?: (attachment: IFormAttachment) => void;
+  showSubmissionStatus?: boolean;
 };
 
 export function FormAttachmentRow({
   attachment,
   eventAuthor,
   onFill,
+  showSubmissionStatus = !!onFill,
 }: FormAttachmentRowProps) {
   const intl = useIntl();
   const { user } = useUser();
   const [title, setTitle] = useState<string | null>(null);
   const { status } = useFormSubmissionStatus(
-    onFill ? attachment.naddr : undefined,
+    showSubmissionStatus ? attachment.naddr : undefined,
     user?.pubkey,
   );
   const submitted = status.state === "submitted";
   const hasEditAccess = !!user?.pubkey && eventAuthor === user.pubkey;
+  const canViewResponsesInFormstr = hasEditAccess && !attachment.viewKey;
 
   useEffect(() => {
     let cancelled = false;
@@ -81,7 +84,7 @@ export function FormAttachmentRow({
           })}
         </Button>
       )}
-      {hasEditAccess && (
+      {canViewResponsesInFormstr && (
         <Button
           variant="text"
           size="small"

--- a/src/components/FormAttachmentRow.tsx
+++ b/src/components/FormAttachmentRow.tsx
@@ -1,0 +1,112 @@
+import { useEffect, useState } from "react";
+import { Box, Button, Typography } from "@mui/material";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import OpenInNewIcon from "@mui/icons-material/OpenInNew";
+import { FormstrSDK } from "@formstr/sdk";
+import { useIntl } from "react-intl";
+import { useUser } from "../stores/user";
+import { useFormSubmissionStatus } from "../hooks/useFormSubmissionStatus";
+import { buildFormstrResponsesUrl } from "../utils/formLink";
+import type { IFormAttachment } from "../utils/types";
+
+type FormAttachmentRowProps = {
+  attachment: IFormAttachment;
+  eventAuthor?: string;
+  onFill?: (attachment: IFormAttachment) => void;
+};
+
+export function FormAttachmentRow({
+  attachment,
+  eventAuthor,
+  onFill,
+}: FormAttachmentRowProps) {
+  const intl = useIntl();
+  const { user } = useUser();
+  const [title, setTitle] = useState<string | null>(null);
+  const { status } = useFormSubmissionStatus(
+    onFill ? attachment.naddr : undefined,
+    user?.pubkey,
+  );
+  const submitted = status.state === "submitted";
+  const hasEditAccess = !!user?.pubkey && eventAuthor === user.pubkey;
+
+  useEffect(() => {
+    let cancelled = false;
+
+    setTitle(null);
+
+    const resolveTitle = async () => {
+      try {
+        const sdk = new FormstrSDK();
+        const form = (await (attachment.viewKey
+          ? sdk.fetchFormWithViewKey(attachment.naddr, attachment.viewKey)
+          : sdk.fetchForm(attachment.naddr))) as { name?: string };
+        const nextTitle = form.name?.trim();
+
+        if (!cancelled) {
+          setTitle(nextTitle || null);
+        }
+      } catch {
+        if (!cancelled) {
+          setTitle(null);
+        }
+      }
+    };
+
+    void resolveTitle();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [attachment.naddr, attachment.viewKey]);
+
+  const fallbackLabel =
+    attachment.naddr.length > 24
+      ? `${attachment.naddr.slice(0, 12)}…${attachment.naddr.slice(-8)}`
+      : attachment.naddr;
+
+  return (
+    <Box display="flex" alignItems="center" gap={1} flexWrap="wrap">
+      {onFill && (
+        <Button
+          variant={submitted ? "text" : "outlined"}
+          size="small"
+          onClick={() => onFill(attachment)}
+          startIcon={
+            submitted ? <CheckCircleIcon color="success" /> : undefined
+          }
+        >
+          {intl.formatMessage({
+            id: submitted ? "form.viewOrUpdate" : "form.fillOut",
+          })}
+        </Button>
+      )}
+      {hasEditAccess && (
+        <Button
+          variant="text"
+          size="small"
+          href={buildFormstrResponsesUrl(attachment)}
+          target="_blank"
+          rel="noopener noreferrer"
+          endIcon={<OpenInNewIcon fontSize="inherit" />}
+        >
+          {intl.formatMessage({ id: "formResponses.viewButton" })}
+        </Button>
+      )}
+      <Typography
+        variant="caption"
+        color="text.secondary"
+        sx={
+          title
+            ? { wordBreak: "break-word" }
+            : {
+                fontFamily: "monospace",
+                wordBreak: "break-all",
+              }
+        }
+      >
+        {title ?? fallbackLabel}
+      </Typography>
+    </Box>
+  );
+}

--- a/src/components/FormFillerDialog.tsx
+++ b/src/components/FormFillerDialog.tsx
@@ -48,6 +48,7 @@ import type { IFormAttachment } from "../utils/types";
 import { signerManager } from "../common/signer";
 import { useFormSubmissionStatus } from "../hooks/useFormSubmissionStatus";
 import { useUser } from "../stores/user";
+import { fetchAttachedFormCached } from "../utils/formAttachment";
 import { buildFormstrUrl } from "../utils/formLink";
 
 type SdkOption = {
@@ -259,11 +260,7 @@ export function FormFillerDialog({
       // accumulate across retries or re-opened dialogs.
       const sdk = new FormstrSDK();
       sdkRef.current = sdk;
-      const fetched = (await (
-        attachment.viewKey
-          ? sdk.fetchFormWithViewKey(attachment.naddr, attachment.viewKey)
-          : sdk.fetchForm(attachment.naddr)
-      )) as SdkForm;
+      const fetched = await fetchAttachedFormCached<SdkForm>(attachment);
       sdk.renderHtml(fetched as never);
       setForm(fetched);
     } catch (err) {

--- a/src/components/FormFillerDialog.tsx
+++ b/src/components/FormFillerDialog.tsx
@@ -63,7 +63,6 @@ type SdkField = {
   options?: SdkOption[] | unknown;
   config?: { renderElement?: string };
 };
-
 type SdkForm = {
   id: string;
   name?: string;
@@ -279,6 +278,8 @@ export function FormFillerDialog({
     }
   }, [attachment, intl]);
 
+  // Fetch the form template whenever we need to render either the editable
+  // SDK form or a read-only summary of the user's previous response.
   useEffect(() => {
     const shouldRender =
       open &&
@@ -414,6 +415,7 @@ export function FormFillerDialog({
                     border: `1px solid ${theme.palette.divider}`,
                     borderRadius: 1,
                     overflow: "hidden",
+                    width: "100%",
                   }}
                 >
                   <Box

--- a/src/components/FormFillerDialog.tsx
+++ b/src/components/FormFillerDialog.tsx
@@ -19,7 +19,7 @@
  * - On submit failure: surface the error and let the user retry.
  */
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Alert,
   Box,
@@ -38,30 +38,178 @@ import {
 import type { Theme } from "@mui/material/styles";
 import { alpha } from "@mui/material/styles";
 import CloseIcon from "@mui/icons-material/Close";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import { FormstrSDK } from "@formstr/sdk";
+import dayjs from "dayjs";
 import type { Event as NostrEvent, EventTemplate } from "nostr-tools";
 import { useIntl } from "react-intl";
 import type { IFormAttachment } from "../utils/types";
 import { signerManager } from "../common/signer";
+import { useFormSubmissionStatus } from "../hooks/useFormSubmissionStatus";
+import { useUser } from "../stores/user";
 import { buildFormstrUrl } from "../utils/formLink";
 
-// SDK's NormalizedForm shape (subset we touch)
+type SdkOption = {
+  id: string;
+  labelHtml: string;
+  config?: { isOther?: boolean };
+};
+
+type SdkField = {
+  id: string;
+  type: string;
+  labelHtml: string;
+  options?: SdkOption[] | unknown;
+  config?: { renderElement?: string };
+};
+
 type SdkForm = {
   id: string;
   name?: string;
   html?: { form: string };
+  fields?: Record<string, SdkField>;
+  fieldOrder?: string[];
 };
+
+type ResponseRow = {
+  fieldId: string;
+  question: string;
+  answer: string;
+};
+
+function plainText(html: string | undefined): string {
+  if (!html) return "";
+  if (typeof document === "undefined") {
+    return html.replace(/<[^>]*>/g, "").trim();
+  }
+  const div = document.createElement("div");
+  div.innerHTML = html;
+  return (div.textContent || div.innerText || "").trim();
+}
+
+function parseMetadata(raw: string | undefined): Record<string, unknown> {
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function formatAnswer(
+  field: SdkField | undefined,
+  rawValue: string | undefined,
+  metadataRaw: string | undefined,
+  noAnswerLabel: string,
+): string {
+  if (!rawValue) return noAnswerLabel;
+  if (!field) return rawValue;
+
+  if (field.type === "option" && Array.isArray(field.options)) {
+    const metadata = parseMetadata(metadataRaw);
+    const selectedIds = rawValue.split(";").filter(Boolean);
+    const labels = selectedIds.map((id) => {
+      const options = Array.isArray(field.options) ? field.options : [];
+      const option = options.find((entry) => entry.id === id);
+      const label = option ? plainText(option.labelHtml) : id;
+      if (option?.config?.isOther && typeof metadata.message === "string") {
+        return `${label} (${metadata.message})`;
+      }
+      return label;
+    });
+    return labels.length > 0 ? labels.join(", ") : rawValue;
+  }
+
+  if (field.type === "grid") {
+    try {
+      const parsed = JSON.parse(rawValue) as Record<string, string>;
+      if (parsed && typeof parsed === "object") {
+        return Object.entries(parsed)
+          .map(([rowId, selected]) => `${rowId}: ${selected}`)
+          .join(" | ");
+      }
+    } catch {
+      return rawValue;
+    }
+  }
+
+  if (field.config?.renderElement === "datetime") {
+    const timestamp = Number(rawValue);
+    if (Number.isFinite(timestamp)) {
+      return new Date(timestamp * 1000).toLocaleString();
+    }
+  }
+
+  if (field.config?.renderElement === "fileUpload") {
+    try {
+      const metadata = JSON.parse(rawValue) as { filename?: string };
+      if (metadata.filename) return metadata.filename;
+    } catch {
+      return rawValue;
+    }
+  }
+
+  return rawValue;
+}
+
+function responseRowsFromEvent(
+  response: NostrEvent,
+  form: SdkForm | null,
+  noAnswerLabel: string,
+  unknownQuestionLabel: string,
+): ResponseRow[] {
+  const responseTags = response.tags.filter(
+    (tag) => tag[0] === "response" && tag[1],
+  );
+  const tagsByField = new Map<string, string[]>();
+  for (const tag of responseTags) {
+    tagsByField.set(tag[1], tag);
+  }
+
+  const rows: ResponseRow[] = [];
+  const consumed = new Set<string>();
+  const fields = form?.fields ?? {};
+  const fieldOrder = form?.fieldOrder ?? [];
+
+  for (const fieldId of fieldOrder) {
+    const field = fields[fieldId];
+    if (!field || field.type === "label") continue;
+    const tag = tagsByField.get(fieldId);
+    if (!tag) continue;
+    consumed.add(fieldId);
+    rows.push({
+      fieldId,
+      question:
+        plainText(field.labelHtml) || `${unknownQuestionLabel} ${fieldId}`,
+      answer: formatAnswer(field, tag[2], tag[3], noAnswerLabel),
+    });
+  }
+
+  for (const tag of responseTags) {
+    const fieldId = tag[1];
+    if (consumed.has(fieldId)) continue;
+    const field = fields[fieldId];
+    rows.push({
+      fieldId,
+      question: field
+        ? plainText(field.labelHtml) || `${unknownQuestionLabel} ${fieldId}`
+        : `${unknownQuestionLabel} ${fieldId}`,
+      answer: formatAnswer(field, tag[2], tag[3], noAnswerLabel),
+    });
+  }
+
+  return rows;
+}
 
 type Props = {
   open: boolean;
   attachment: IFormAttachment | null;
-  /** 1-based position of this attachment in a list, for multi-form flows. */
   index?: number;
-  /** Total number of attachments in the list, for multi-form flows. */
   total?: number;
   onClose: () => void;
-  onSubmitted: (response: NostrEvent) => void;
+  onSubmitted: (response: NostrEvent | null) => void;
 };
 
 export function FormFillerDialog({
@@ -77,14 +225,29 @@ export function FormFillerDialog({
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
   const containerRef = useRef<HTMLDivElement | null>(null);
   const sdkRef = useRef<FormstrSDK | null>(null);
-  // Stored by the form-setup effect so DialogActions can trigger submit.
   const submitFnRef = useRef<(() => void) | null>(null);
+  const { user } = useUser();
+  const { status, markSubmitted } = useFormSubmissionStatus(
+    open ? attachment?.naddr : undefined,
+    open ? user?.pubkey : undefined,
+  );
+  const alreadySubmitted = status.state === "submitted";
+  const [resubmitting, setResubmitting] = useState(false);
 
   const [form, setForm] = useState<SdkForm | null>(null);
   const [loading, setLoading] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [fetchError, setFetchError] = useState<string | null>(null);
   const [submitError, setSubmitError] = useState<string | null>(null);
+  const responseRows = useMemo(() => {
+    if (status.state !== "submitted" || !status.event) return [];
+    return responseRowsFromEvent(
+      status.event,
+      form,
+      intl.formatMessage({ id: "form.noAnswer" }),
+      intl.formatMessage({ id: "form.unknownQuestion" }),
+    );
+  }, [status, form, intl]);
 
   const fetchForm = useCallback(async () => {
     if (!attachment) return;
@@ -116,20 +279,25 @@ export function FormFillerDialog({
     }
   }, [attachment, intl]);
 
-  // Fetch the form template only when we should render it.
   useEffect(() => {
-    if (open && attachment) fetchForm();
+    const shouldRender =
+      open &&
+      attachment &&
+      (status.state === "not-submitted" ||
+        status.state === "error" ||
+        status.state === "submitted" ||
+        resubmitting);
+    if (shouldRender) fetchForm();
     if (!open) {
       setForm(null);
       setFetchError(null);
       setSubmitError(null);
       sdkRef.current = null;
       submitFnRef.current = null;
+      setResubmitting(false);
     }
-  }, [open, attachment, fetchForm]);
+  }, [open, attachment, fetchForm, status.state, resubmitting]);
 
-  // After form HTML is in the DOM, attach the SDK submit listener and wire
-  // submitFnRef so the DialogActions Submit button can trigger it.
   useEffect(() => {
     if (!form || !sdkRef.current || !containerRef.current) return;
     const sdk = sdkRef.current;
@@ -142,6 +310,7 @@ export function FormFillerDialog({
     sdk.attachSubmitListener(form as never, signer, {
       onSuccess: ({ event }) => {
         setSubmitting(false);
+        markSubmitted(event);
         onSubmitted(event);
       },
       onError: (err) => {
@@ -159,7 +328,6 @@ export function FormFillerDialog({
     const formEl = root.querySelector("form");
     if (!formEl) return;
 
-    // Wire the external submit button.
     submitFnRef.current = () => formEl.requestSubmit();
 
     const onSubmitDom = () => {
@@ -171,9 +339,10 @@ export function FormFillerDialog({
       submitFnRef.current = null;
       formEl.removeEventListener("submit", onSubmitDom);
     };
-  }, [form, intl, onSubmitted]);
+  }, [form, intl, onSubmitted, markSubmitted]);
 
-  const showForm = !loading && !fetchError && form;
+  const showForm =
+    !loading && !fetchError && form && !(alreadySubmitted && !resubmitting);
 
   return (
     <Dialog
@@ -205,10 +374,98 @@ export function FormFillerDialog({
       </DialogTitle>
 
       <DialogContent dividers sx={{ px: { xs: 2, sm: 3 }, py: 3 }}>
-        {loading && (
+        {(status.state === "loading" || loading) && (
           <Box display="flex" justifyContent="center" py={6}>
             <CircularProgress />
           </Box>
+        )}
+
+        {alreadySubmitted && !resubmitting && !loading && (
+          <Stack spacing={2}>
+            <Alert
+              icon={<CheckCircleIcon fontSize="inherit" />}
+              severity="success"
+            >
+              {intl.formatMessage({ id: "form.alreadySubmitted" })}
+            </Alert>
+            <Stack direction="row" spacing={1}>
+              <Button
+                variant="contained"
+                onClick={() => {
+                  if (status.state === "submitted") {
+                    onSubmitted(status.event ?? null);
+                  } else {
+                    onClose();
+                  }
+                }}
+              >
+                {intl.formatMessage({ id: "form.continue" })}
+              </Button>
+              <Button variant="outlined" onClick={() => setResubmitting(true)}>
+                {intl.formatMessage({ id: "form.submitAgain" })}
+              </Button>
+            </Stack>
+
+            {status.state === "submitted" &&
+              status.event &&
+              responseRows.length > 0 && (
+                <Box
+                  sx={{
+                    border: `1px solid ${theme.palette.divider}`,
+                    borderRadius: 1,
+                    overflow: "hidden",
+                  }}
+                >
+                  <Box
+                    sx={{
+                      px: 1.5,
+                      py: 1,
+                      borderBottom: `1px solid ${theme.palette.divider}`,
+                      bgcolor: "action.hover",
+                    }}
+                  >
+                    <Typography variant="subtitle2">
+                      {intl.formatMessage({ id: "form.yourResponse" })}
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      {dayjs(status.submittedAt).format("YYYY-MM-DD HH:mm")}
+                    </Typography>
+                  </Box>
+                  <Stack spacing={0}>
+                    {responseRows.map((row, rowIndex) => (
+                      <Box
+                        key={`${row.fieldId}-${rowIndex}`}
+                        sx={{
+                          px: 1.5,
+                          py: 1.25,
+                          borderTop:
+                            rowIndex === 0
+                              ? "none"
+                              : `1px solid ${theme.palette.divider}`,
+                        }}
+                      >
+                        <Typography variant="caption" color="text.secondary">
+                          {row.question}
+                        </Typography>
+                        <Typography
+                          variant="body2"
+                          sx={{ whiteSpace: "pre-wrap" }}
+                        >
+                          {row.answer}
+                        </Typography>
+                      </Box>
+                    ))}
+                  </Stack>
+                </Box>
+              )}
+
+            {status.state === "submitted" &&
+              (!status.event || responseRows.length === 0) && (
+                <Typography variant="body2" color="text.secondary">
+                  {intl.formatMessage({ id: "form.responseUnavailable" })}
+                </Typography>
+              )}
+          </Stack>
         )}
 
         {fetchError && !loading && (
@@ -221,6 +478,17 @@ export function FormFillerDialog({
             >
               {intl.formatMessage({ id: "form.retry" })}
             </Button>
+            {attachment && (
+              <Button
+                variant="text"
+                href={buildFormstrUrl(attachment)}
+                target="_blank"
+                rel="noopener noreferrer"
+                sx={{ alignSelf: "flex-start" }}
+              >
+                {intl.formatMessage({ id: "form.openExternal" })}
+              </Button>
+            )}
           </Stack>
         )}
 
@@ -231,9 +499,6 @@ export function FormFillerDialog({
                 {submitError}
               </Alert>
             )}
-            {/* SDK-generated HTML styled via scoped sx. Source is a trusted
-                Nostr form template. The SDK's own h2 and submit button are
-                hidden — we render them in the dialog chrome instead. */}
             <Box
               ref={containerRef}
               sx={buildFormSx(theme)}
@@ -253,7 +518,6 @@ export function FormFillerDialog({
           gap: 1,
         }}
       >
-        {/* Always-visible "Open in Formstr" link */}
         {attachment ? (
           <Button
             size="small"
@@ -261,7 +525,11 @@ export function FormFillerDialog({
             href={buildFormstrUrl(attachment)}
             target="_blank"
             rel="noopener noreferrer"
-            sx={{ textTransform: "none", color: "text.secondary", flexShrink: 0 }}
+            sx={{
+              textTransform: "none",
+              color: "text.secondary",
+              flexShrink: 0,
+            }}
           >
             {intl.formatMessage({ id: "form.openExternal" })}
           </Button>
@@ -296,12 +564,6 @@ export function FormFillerDialog({
   );
 }
 
-/**
- * Scoped styles for the SDK-generated form HTML. The SDK emits unstyled
- * standard HTML: `<label>LabelText<input></label>` for text fields and
- * `<fieldset>` for radio groups. We stack everything vertically and apply
- * Material-like input styling.
- */
 function buildFormSx(theme: Theme) {
   return {
     "& form": {
@@ -311,20 +573,13 @@ function buildFormSx(theme: Theme) {
       padding: 0,
       margin: 0,
     },
-    // The SDK duplicates the form name in an h2; DialogTitle already shows it.
     "& form h2": { display: "none" },
-    // We supply our own Submit button in DialogActions.
     "& form button[type='submit']": { display: "none" },
-
-    // label-type fields: plain <div> used for descriptions / section headings.
     "& form > div": {
       fontSize: "0.875rem",
       color: theme.palette.text.secondary,
       lineHeight: 1.6,
     },
-
-    // Text field wrappers: <label>LabelText<input ...></label>
-    // The label element acts as both the caption and the wrapper.
     "& form > label": {
       display: "flex",
       flexDirection: "column",
@@ -334,8 +589,6 @@ function buildFormSx(theme: Theme) {
       color: theme.palette.text.secondary,
       cursor: "default",
     },
-
-    // Text inputs
     "& form input[type='text']": {
       boxSizing: "border-box",
       width: "100%",
@@ -357,8 +610,6 @@ function buildFormSx(theme: Theme) {
       borderColor: theme.palette.primary.main,
       boxShadow: `0 0 0 3px ${alpha(theme.palette.primary.main, 0.15)}`,
     },
-
-    // Radio group fieldsets
     "& form fieldset": {
       border: "none",
       padding: 0,
@@ -371,7 +622,6 @@ function buildFormSx(theme: Theme) {
       color: theme.palette.text.secondary,
     },
     "& form fieldset br": { display: "none" },
-    // Individual radio option labels (inside fieldset)
     "& form fieldset label": {
       display: "flex",
       flexDirection: "row",

--- a/src/components/InvitationPanel.tsx
+++ b/src/components/InvitationPanel.tsx
@@ -49,7 +49,7 @@ export function InvitationPanel() {
     null,
   );
   const [addDialogGiftWrapId, setAddDialogGiftWrapId] = useState<string>("");
-  const [addDialogInitialCalendarId, setAddDialogInitialCalendarId] =
+  const [addDialogDefaultCalendarId, setAddDialogDefaultCalendarId] =
     useState("");
   const pendingInvitations = invitations
     .filter((inv) => inv.status === "pending")
@@ -82,7 +82,7 @@ export function InvitationPanel() {
   } = useAcceptWithFormsFlow<ICalendarEvent>({
     onFinalize: finalizeAccept,
     onCancel: (currentPendingAccept) => {
-      setAddDialogInitialCalendarId(currentPendingAccept.calendarId);
+      setAddDialogDefaultCalendarId(currentPendingAccept.calendarId);
       setAddDialogGiftWrapId(currentPendingAccept.giftWrapId ?? "");
       setAddDialogEvent(currentPendingAccept.context);
     },
@@ -90,7 +90,7 @@ export function InvitationPanel() {
 
   const handleAccept = (giftWrapId: string, event?: ICalendarEvent) => {
     if (event) {
-      setAddDialogInitialCalendarId("");
+      setAddDialogDefaultCalendarId("");
       setAddDialogEvent(event);
       setAddDialogGiftWrapId(giftWrapId);
     }
@@ -99,7 +99,7 @@ export function InvitationPanel() {
   const closeAddDialog = () => {
     setAddDialogEvent(null);
     setAddDialogGiftWrapId("");
-    setAddDialogInitialCalendarId("");
+    setAddDialogDefaultCalendarId("");
   };
 
   const handleAcceptConfirm = async (calendarId: string) => {
@@ -246,7 +246,7 @@ export function InvitationPanel() {
           onClose={closeAddDialog}
           event={addDialogEvent}
           onAccept={handleAcceptConfirm}
-          initialCalendarId={addDialogInitialCalendarId || undefined}
+          defaultCalendarId={addDialogDefaultCalendarId || undefined}
         />
       )}
 

--- a/src/components/InvitationPanel.tsx
+++ b/src/components/InvitationPanel.tsx
@@ -40,7 +40,7 @@ export function InvitationPanel() {
 
   useEffect(() => {
     fetchCalendars();
-  }, []);
+  }, [fetchCalendars]);
 
   const [addDialogEvent, setAddDialogEvent] = useState<ICalendarEvent | null>(
     null,
@@ -57,7 +57,6 @@ export function InvitationPanel() {
   const pendingInvitations = invitations
     .filter((inv) => inv.status === "pending")
     .sort((a, b) => b.receivedAt - a.receivedAt);
-  console.log(pendingInvitations);
 
   const handleAccept = (giftWrapId: string, event?: ICalendarEvent) => {
     if (event) {

--- a/src/components/InvitationPanel.tsx
+++ b/src/components/InvitationPanel.tsx
@@ -9,7 +9,7 @@
  * and dashed border styling. Users can accept (add to calendar) or dismiss.
  */
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
   Box,
   Typography,
@@ -30,6 +30,7 @@ import { Participant } from "./Participant";
 import type { ICalendarEvent } from "../utils/types";
 import { FormattedMessage, useIntl } from "react-intl";
 import { useCalendarLists } from "../stores/calendarLists";
+import { useAcceptWithFormsFlow } from "../hooks/useAcceptWithFormsFlow";
 import { FormAttachmentRow } from "./FormAttachmentRow";
 
 export function InvitationPanel() {
@@ -50,17 +51,42 @@ export function InvitationPanel() {
   const [addDialogGiftWrapId, setAddDialogGiftWrapId] = useState<string>("");
   const [addDialogInitialCalendarId, setAddDialogInitialCalendarId] =
     useState("");
-  // Pending acceptance after AddToCalendarDialog confirms — we hold here while
-  // walking through any attached forms before finalizing the accept.
-  const [pendingAccept, setPendingAccept] = useState<{
-    giftWrapId: string;
-    calendarId: string;
-    event: ICalendarEvent;
-    formIndex: number;
-  } | null>(null);
   const pendingInvitations = invitations
     .filter((inv) => inv.status === "pending")
     .sort((a, b) => b.receivedAt - a.receivedAt);
+
+  const finalizeAccept = useCallback(
+    async ({
+      calendarId,
+      giftWrapId,
+    }: {
+      calendarId: string;
+      giftWrapId?: string;
+    }) => {
+      if (!giftWrapId) {
+        throw new Error("Missing gift wrap id for invitation acceptance");
+      }
+
+      await acceptInvitation(giftWrapId, calendarId);
+    },
+    [acceptInvitation],
+  );
+
+  const {
+    pendingAccept,
+    pendingForm,
+    formCount,
+    startAccept,
+    advanceAccept,
+    cancelAccept,
+  } = useAcceptWithFormsFlow<ICalendarEvent>({
+    onFinalize: finalizeAccept,
+    onCancel: (currentPendingAccept) => {
+      setAddDialogInitialCalendarId(currentPendingAccept.calendarId);
+      setAddDialogGiftWrapId(currentPendingAccept.giftWrapId ?? "");
+      setAddDialogEvent(currentPendingAccept.context);
+    },
+  });
 
   const handleAccept = (giftWrapId: string, event?: ICalendarEvent) => {
     if (event) {
@@ -81,39 +107,13 @@ export function InvitationPanel() {
     const giftWrapId = addDialogGiftWrapId;
     closeAddDialog();
     if (!event) return;
-    const forms = event.forms ?? [];
-    if (forms.length > 0) {
-      // Walk forms first; only finalize accept after they're submitted.
-      setPendingAccept({ giftWrapId, calendarId, event, formIndex: 0 });
-      return;
-    }
-    await acceptInvitation(giftWrapId, calendarId);
+    await startAccept({
+      calendarId,
+      giftWrapId,
+      attachments: event.forms ?? [],
+      context: event,
+    });
   };
-
-  const handlePendingAcceptClose = () => {
-    if (!pendingAccept) return;
-    setAddDialogInitialCalendarId(pendingAccept.calendarId);
-    setAddDialogGiftWrapId(pendingAccept.giftWrapId);
-    setAddDialogEvent(pendingAccept.event);
-    setPendingAccept(null);
-  };
-
-  const advanceForm = async () => {
-    if (!pendingAccept) return;
-    const next = pendingAccept.formIndex + 1;
-    const forms = pendingAccept.event.forms ?? [];
-    if (next >= forms.length) {
-      const { giftWrapId, calendarId } = pendingAccept;
-      setPendingAccept(null);
-      await acceptInvitation(giftWrapId, calendarId);
-    } else {
-      setPendingAccept({ ...pendingAccept, formIndex: next });
-    }
-  };
-
-  const pendingFormIndex = pendingAccept?.formIndex ?? 0;
-  const pendingForms = pendingAccept?.event.forms ?? [];
-  const pendingForm = pendingForms[pendingFormIndex] ?? null;
 
   return (
     <Box p={2} maxWidth={isMobile ? "100%" : 600} mx="auto">
@@ -255,11 +255,11 @@ export function InvitationPanel() {
         <FormFillerDialog
           open
           attachment={pendingForm}
-          index={pendingFormIndex + 1}
-          total={pendingForms.length}
-          onClose={handlePendingAcceptClose}
+          index={pendingAccept ? pendingAccept.formIndex + 1 : undefined}
+          total={formCount}
+          onClose={cancelAccept}
           onSubmitted={() => {
-            void advanceForm();
+            void advanceAccept();
           }}
         />
       )}

--- a/src/components/InvitationPanel.tsx
+++ b/src/components/InvitationPanel.tsx
@@ -48,6 +48,8 @@ export function InvitationPanel() {
     null,
   );
   const [addDialogGiftWrapId, setAddDialogGiftWrapId] = useState<string>("");
+  const [addDialogInitialCalendarId, setAddDialogInitialCalendarId] =
+    useState("");
   // Pending acceptance after AddToCalendarDialog confirms — we hold here while
   // walking through any attached forms before finalizing the accept.
   const [pendingAccept, setPendingAccept] = useState<{
@@ -62,15 +64,22 @@ export function InvitationPanel() {
 
   const handleAccept = (giftWrapId: string, event?: ICalendarEvent) => {
     if (event) {
+      setAddDialogInitialCalendarId("");
       setAddDialogEvent(event);
       setAddDialogGiftWrapId(giftWrapId);
     }
   };
 
+  const closeAddDialog = () => {
+    setAddDialogEvent(null);
+    setAddDialogGiftWrapId("");
+    setAddDialogInitialCalendarId("");
+  };
+
   const handleAcceptConfirm = async (calendarId: string) => {
     const event = addDialogEvent;
     const giftWrapId = addDialogGiftWrapId;
-    setAddDialogEvent(null);
+    closeAddDialog();
     if (!event) return;
     const forms = event.forms ?? [];
     if (forms.length > 0) {
@@ -79,6 +88,14 @@ export function InvitationPanel() {
       return;
     }
     await acceptInvitation(giftWrapId, calendarId);
+  };
+
+  const handlePendingAcceptClose = () => {
+    if (!pendingAccept) return;
+    setAddDialogInitialCalendarId(pendingAccept.calendarId);
+    setAddDialogGiftWrapId(pendingAccept.giftWrapId);
+    setAddDialogEvent(pendingAccept.event);
+    setPendingAccept(null);
   };
 
   const advanceForm = async () => {
@@ -187,6 +204,7 @@ export function InvitationPanel() {
                       <FormAttachmentRow
                         key={attachment.naddr}
                         attachment={attachment}
+                        showSubmissionStatus={false}
                       />
                     ))}
                   </Stack>
@@ -225,9 +243,10 @@ export function InvitationPanel() {
       {addDialogEvent && (
         <AddToCalendarDialog
           open={!!addDialogEvent}
-          onClose={() => setAddDialogEvent(null)}
+          onClose={closeAddDialog}
           event={addDialogEvent}
           onAccept={handleAcceptConfirm}
+          initialCalendarId={addDialogInitialCalendarId || undefined}
         />
       )}
 
@@ -238,7 +257,7 @@ export function InvitationPanel() {
           attachment={pendingForm}
           index={pendingFormIndex + 1}
           total={pendingForms.length}
-          onClose={() => setPendingAccept(null)}
+          onClose={handlePendingAcceptClose}
           onSubmitted={() => {
             void advanceForm();
           }}

--- a/src/components/InvitationPanel.tsx
+++ b/src/components/InvitationPanel.tsx
@@ -16,6 +16,7 @@ import {
   Button,
   Paper,
   IconButton,
+  Stack,
   useTheme,
   useMediaQuery,
 } from "@mui/material";
@@ -29,6 +30,7 @@ import { Participant } from "./Participant";
 import type { ICalendarEvent } from "../utils/types";
 import { FormattedMessage, useIntl } from "react-intl";
 import { useCalendarLists } from "../stores/calendarLists";
+import { FormAttachmentRow } from "./FormAttachmentRow";
 
 export function InvitationPanel() {
   const intl = useIntl();
@@ -170,6 +172,26 @@ export function InvitationPanel() {
                   }}
                 />
               </Box>
+              {invitation.event.forms && invitation.event.forms.length > 0 && (
+                <Box mt={1.5}>
+                  <Typography
+                    variant="caption"
+                    color="text.secondary"
+                    display="block"
+                    mb={0.75}
+                  >
+                    {intl.formatMessage({ id: "form.attachments" })}
+                  </Typography>
+                  <Stack spacing={0.75}>
+                    {invitation.event.forms.map((attachment) => (
+                      <FormAttachmentRow
+                        key={attachment.naddr}
+                        attachment={attachment}
+                      />
+                    ))}
+                  </Stack>
+                </Box>
+              )}
             </Box>
           ) : (
             <Typography variant="body2" color="text.secondary">

--- a/src/hooks/useAcceptWithFormsFlow.test.ts
+++ b/src/hooks/useAcceptWithFormsFlow.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  createPendingAcceptWithForms,
+  getNextPendingAcceptWithForms,
+} from "./useAcceptWithFormsFlow";
+
+const attachments = [{ naddr: "naddr1first" }, { naddr: "naddr1second" }];
+
+describe("useAcceptWithFormsFlow helpers", () => {
+  it("returns null when there are no attachments", () => {
+    expect(
+      createPendingAcceptWithForms({
+        calendarId: "cal-1",
+        attachments: [],
+        context: "event-1",
+      }),
+    ).toBeNull();
+  });
+
+  it("creates pending acceptance from the first attachment", () => {
+    expect(
+      createPendingAcceptWithForms({
+        calendarId: "cal-1",
+        giftWrapId: "wrap-1",
+        attachments,
+        context: "event-1",
+      }),
+    ).toEqual({
+      calendarId: "cal-1",
+      giftWrapId: "wrap-1",
+      attachments,
+      context: "event-1",
+      formIndex: 0,
+    });
+  });
+
+  it("advances until the final attachment, then returns null", () => {
+    const pendingAccept = createPendingAcceptWithForms({
+      calendarId: "cal-1",
+      giftWrapId: "wrap-1",
+      attachments,
+      context: "event-1",
+    });
+
+    expect(pendingAccept).not.toBeNull();
+    expect(getNextPendingAcceptWithForms(pendingAccept!)).toEqual({
+      ...pendingAccept,
+      formIndex: 1,
+    });
+    expect(
+      getNextPendingAcceptWithForms({
+        ...pendingAccept!,
+        formIndex: 1,
+      }),
+    ).toBeNull();
+  });
+});

--- a/src/hooks/useAcceptWithFormsFlow.ts
+++ b/src/hooks/useAcceptWithFormsFlow.ts
@@ -1,0 +1,120 @@
+import { useCallback, useMemo, useState } from "react";
+import type { IFormAttachment } from "../utils/types";
+
+export type AcceptWithFormsStartParams<TContext> = {
+  calendarId: string;
+  giftWrapId?: string;
+  attachments: IFormAttachment[];
+  context: TContext;
+};
+
+export type PendingAcceptWithForms<TContext> =
+  AcceptWithFormsStartParams<TContext> & {
+    formIndex: number;
+  };
+
+export function createPendingAcceptWithForms<TContext>(
+  params: AcceptWithFormsStartParams<TContext>,
+): PendingAcceptWithForms<TContext> | null {
+  if (params.attachments.length === 0) {
+    return null;
+  }
+
+  return {
+    ...params,
+    formIndex: 0,
+  };
+}
+
+export function getNextPendingAcceptWithForms<TContext>(
+  pendingAccept: PendingAcceptWithForms<TContext>,
+): PendingAcceptWithForms<TContext> | null {
+  const nextIndex = pendingAccept.formIndex + 1;
+  if (nextIndex >= pendingAccept.attachments.length) {
+    return null;
+  }
+
+  return {
+    ...pendingAccept,
+    formIndex: nextIndex,
+  };
+}
+
+type UseAcceptWithFormsFlowParams<TContext> = {
+  onFinalize: (params: {
+    calendarId: string;
+    giftWrapId?: string;
+  }) => Promise<void>;
+  onCancel?: (pendingAccept: PendingAcceptWithForms<TContext>) => void;
+};
+
+export function useAcceptWithFormsFlow<TContext>({
+  onFinalize,
+  onCancel,
+}: UseAcceptWithFormsFlowParams<TContext>) {
+  const [pendingAccept, setPendingAccept] =
+    useState<PendingAcceptWithForms<TContext> | null>(null);
+
+  const startAccept = useCallback(
+    async (params: AcceptWithFormsStartParams<TContext>) => {
+      if (!params.calendarId) {
+        return false;
+      }
+
+      const nextPendingAccept = createPendingAcceptWithForms(params);
+      if (!nextPendingAccept) {
+        await onFinalize({
+          calendarId: params.calendarId,
+          giftWrapId: params.giftWrapId,
+        });
+        return false;
+      }
+
+      setPendingAccept(nextPendingAccept);
+      return true;
+    },
+    [onFinalize],
+  );
+
+  const advanceAccept = useCallback(async () => {
+    if (!pendingAccept) {
+      return;
+    }
+
+    const nextPendingAccept = getNextPendingAcceptWithForms(pendingAccept);
+    if (nextPendingAccept) {
+      setPendingAccept(nextPendingAccept);
+      return;
+    }
+
+    const { calendarId, giftWrapId } = pendingAccept;
+    setPendingAccept(null);
+    await onFinalize({ calendarId, giftWrapId });
+  }, [onFinalize, pendingAccept]);
+
+  const cancelAccept = useCallback(() => {
+    if (!pendingAccept) {
+      return;
+    }
+
+    setPendingAccept(null);
+    onCancel?.(pendingAccept);
+  }, [onCancel, pendingAccept]);
+
+  const pendingForm = useMemo(() => {
+    if (!pendingAccept) {
+      return null;
+    }
+
+    return pendingAccept.attachments[pendingAccept.formIndex] ?? null;
+  }, [pendingAccept]);
+
+  return {
+    pendingAccept,
+    pendingForm,
+    formCount: pendingAccept?.attachments.length ?? 0,
+    startAccept,
+    advanceAccept,
+    cancelAccept,
+  };
+}

--- a/src/hooks/useFormSubmissionStatus.ts
+++ b/src/hooks/useFormSubmissionStatus.ts
@@ -1,0 +1,80 @@
+/**
+ * Hook: useFormSubmissionStatus
+ *
+ * Resolves whether `userPubkey` has already submitted an NIP-101 form
+ * response (kind 1069) for the form referenced by `naddr`, by querying
+ * relays directly. The relay-backed result is the canonical answer —
+ * we do NOT cache "submitted" in local memory across reloads.
+ *
+ * `markSubmitted()` is exposed so the UI can flip the status optimistically
+ * after a successful in-app submission. The next mount will re-verify
+ * against relays so an optimistic flag never silently masks reality.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { fetchUserFormResponse } from "../common/nostr";
+import { getFormCoordinate, getFormRelayHints } from "../utils/formLink";
+import type { Event as NostrEvent } from "nostr-tools";
+
+export type FormSubmissionStatus =
+  | { state: "idle" }
+  | { state: "loading" }
+  | { state: "submitted"; event: NostrEvent | null; submittedAt: number }
+  | { state: "not-submitted" }
+  | { state: "error"; error: string };
+
+export function useFormSubmissionStatus(
+  naddr: string | undefined,
+  userPubkey: string | undefined,
+) {
+  const [status, setStatus] = useState<FormSubmissionStatus>({ state: "idle" });
+
+  const refresh = useCallback(async () => {
+    if (!naddr || !userPubkey) {
+      setStatus({ state: "idle" });
+      return;
+    }
+    const coordinate = getFormCoordinate(naddr);
+    if (!coordinate) {
+      setStatus({ state: "error", error: "Invalid form address" });
+      return;
+    }
+    setStatus({ state: "loading" });
+    try {
+      const event = await fetchUserFormResponse(
+        coordinate,
+        userPubkey,
+        getFormRelayHints(naddr),
+      );
+      if (event) {
+        setStatus({
+          state: "submitted",
+          event,
+          submittedAt: event.created_at * 1000,
+        });
+      } else {
+        setStatus({ state: "not-submitted" });
+      }
+    } catch (err) {
+      setStatus({
+        state: "error",
+        error: err instanceof Error ? err.message : "Lookup failed",
+      });
+    }
+  }, [naddr, userPubkey]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  /** Mark optimistically submitted; relays remain the source of truth on reload. */
+  const markSubmitted = useCallback((event: NostrEvent) => {
+    setStatus({
+      state: "submitted",
+      event,
+      submittedAt: event.created_at * 1000,
+    });
+  }, []);
+
+  return { status, refresh, markSubmitted };
+}

--- a/src/hooks/useFormSubmissionStatus.ts
+++ b/src/hooks/useFormSubmissionStatus.ts
@@ -13,7 +13,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { fetchUserFormResponse } from "../common/nostr";
-import { getFormCoordinate, getFormRelayHints } from "../utils/formLink";
+import { getFormAddress } from "../utils/formLink";
 import type { Event as NostrEvent } from "nostr-tools";
 
 export type FormSubmissionStatus =
@@ -34,17 +34,17 @@ export function useFormSubmissionStatus(
       setStatus({ state: "idle" });
       return;
     }
-    const coordinate = getFormCoordinate(naddr);
-    if (!coordinate) {
+    const formAddress = getFormAddress(naddr);
+    if (!formAddress) {
       setStatus({ state: "error", error: "Invalid form address" });
       return;
     }
     setStatus({ state: "loading" });
     try {
       const event = await fetchUserFormResponse(
-        coordinate,
+        formAddress.coordinate,
         userPubkey,
-        getFormRelayHints(naddr),
+        formAddress.relayHints,
       );
       if (event) {
         setStatus({

--- a/src/utils/formAttachment.ts
+++ b/src/utils/formAttachment.ts
@@ -1,0 +1,37 @@
+import { FormstrSDK } from "@formstr/sdk";
+import type { IFormAttachment } from "./types";
+
+const formRequestCache = new Map<string, Promise<unknown>>();
+
+function getAttachmentCacheKey(attachment: IFormAttachment) {
+  return `${attachment.naddr}::${attachment.viewKey ?? ""}`;
+}
+
+export function fetchAttachedForm<T>(
+  attachment: IFormAttachment,
+  sdk: FormstrSDK = new FormstrSDK(),
+): Promise<T> {
+  return (
+    attachment.viewKey
+      ? sdk.fetchFormWithViewKey(attachment.naddr, attachment.viewKey)
+      : sdk.fetchForm(attachment.naddr)
+  ) as Promise<T>;
+}
+
+export function fetchAttachedFormCached<T>(
+  attachment: IFormAttachment,
+): Promise<T> {
+  const cacheKey = getAttachmentCacheKey(attachment);
+  const cachedRequest = formRequestCache.get(cacheKey);
+  if (cachedRequest) {
+    return cachedRequest as Promise<T>;
+  }
+
+  const request = fetchAttachedForm<T>(attachment).catch((error) => {
+    formRequestCache.delete(cacheKey);
+    throw error;
+  });
+
+  formRequestCache.set(cacheKey, request);
+  return request;
+}

--- a/src/utils/formLink.test.ts
+++ b/src/utils/formLink.test.ts
@@ -4,6 +4,8 @@ import {
   buildFormstrUrl,
   extractNaddr,
   extractViewKey,
+  getFormCoordinate,
+  getFormRelayHints,
   parseFormInput,
 } from "./formLink";
 
@@ -177,5 +179,38 @@ describe("buildFormstrUrl", () => {
     expect(buildFormstrUrl({ naddr: SAMPLE_NADDR, viewKey: "a/b" })).toBe(
       `https://formstr.app/f/${SAMPLE_NADDR}?viewKey=a%2Fb`,
     );
+  });
+});
+
+describe("getFormCoordinate", () => {
+  it("returns kind:pubkey:dtag for a valid naddr", () => {
+    expect(getFormCoordinate(SAMPLE_NADDR)).toBe(
+      `${FORM_KIND}:${SAMPLE_PUBKEY}:demo-form`,
+    );
+  });
+
+  it("returns null for non-naddr input", () => {
+    expect(getFormCoordinate("not-an-naddr")).toBeNull();
+    expect(getFormCoordinate("")).toBeNull();
+  });
+});
+
+describe("getFormRelayHints", () => {
+  it("returns the embedded relays", () => {
+    const naddr = naddrEncode({
+      kind: FORM_KIND,
+      pubkey: SAMPLE_PUBKEY,
+      identifier: "x",
+      relays: ["wss://relay.example"],
+    });
+    expect(getFormRelayHints(naddr)).toEqual(["wss://relay.example"]);
+  });
+
+  it("returns empty array when no relays encoded", () => {
+    expect(getFormRelayHints(SAMPLE_NADDR)).toEqual([]);
+  });
+
+  it("returns empty array for invalid input", () => {
+    expect(getFormRelayHints("garbage")).toEqual([]);
   });
 });

--- a/src/utils/formLink.test.ts
+++ b/src/utils/formLink.test.ts
@@ -5,6 +5,7 @@ import {
   buildFormstrUrl,
   extractNaddr,
   extractViewKey,
+  getFormAddress,
   getFormCoordinate,
   getFormRelayHints,
   parseFormInput,
@@ -94,9 +95,7 @@ describe("extractViewKey", () => {
   it("decodes #nkeys1 hash fragment to viewKey (Formstr's modern format)", async () => {
     // Build a real nkeys blob using the SDK's encoder so the test
     // round-trips through the same TLV path the SDK uses at runtime.
-    const { encodeNKeys } = await import(
-      "@formstr/sdk/dist/utils/nkeys.js"
-    );
+    const { encodeNKeys } = await import("@formstr/sdk/dist/utils/nkeys.js");
     const nkeys = encodeNKeys({ viewKey: SAMPLE_VIEW_KEY });
     expect(
       extractViewKey(`https://formstr.app/f/${SAMPLE_NADDR}#${nkeys}`),
@@ -124,9 +123,7 @@ describe("extractViewKey", () => {
 
   it("decodes percent-encoded keys", () => {
     expect(
-      extractViewKey(
-        `https://formstr.app/f/${SAMPLE_NADDR}?viewKey=a%2Fb`,
-      ),
+      extractViewKey(`https://formstr.app/f/${SAMPLE_NADDR}?viewKey=a%2Fb`),
     ).toBe("a/b");
   });
 
@@ -205,6 +202,26 @@ describe("getFormCoordinate", () => {
   it("returns null for non-naddr input", () => {
     expect(getFormCoordinate("not-an-naddr")).toBeNull();
     expect(getFormCoordinate("")).toBeNull();
+  });
+});
+
+describe("getFormAddress", () => {
+  it("returns the coordinate and embedded relay hints", () => {
+    const naddr = naddrEncode({
+      kind: FORM_KIND,
+      pubkey: SAMPLE_PUBKEY,
+      identifier: "x",
+      relays: ["wss://relay.example"],
+    });
+
+    expect(getFormAddress(naddr)).toEqual({
+      coordinate: `${FORM_KIND}:${SAMPLE_PUBKEY}:x`,
+      relayHints: ["wss://relay.example"],
+    });
+  });
+
+  it("returns null for invalid input", () => {
+    expect(getFormAddress("garbage")).toBeNull();
   });
 });
 

--- a/src/utils/formLink.test.ts
+++ b/src/utils/formLink.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { naddrEncode } from "nostr-tools/nip19";
 import {
+  buildFormstrResponsesUrl,
   buildFormstrUrl,
   extractNaddr,
   extractViewKey,
@@ -111,9 +112,7 @@ describe("extractViewKey", () => {
   });
 
   it("prefers nkeys hash over query params when both are present", async () => {
-    const { encodeNKeys } = await import(
-      "@formstr/sdk/dist/utils/nkeys.js"
-    );
+    const { encodeNKeys } = await import("@formstr/sdk/dist/utils/nkeys.js");
     const hashKey = "a".repeat(64);
     const nkeys = encodeNKeys({ viewKey: hashKey });
     expect(
@@ -179,6 +178,20 @@ describe("buildFormstrUrl", () => {
     expect(buildFormstrUrl({ naddr: SAMPLE_NADDR, viewKey: "a/b" })).toBe(
       `https://formstr.app/f/${SAMPLE_NADDR}?viewKey=a%2Fb`,
     );
+  });
+});
+
+describe("buildFormstrResponsesUrl", () => {
+  it("builds a Formstr responses URL when no view key", () => {
+    expect(buildFormstrResponsesUrl({ naddr: SAMPLE_NADDR })).toBe(
+      `https://formstr.app/s/${SAMPLE_NADDR}`,
+    );
+  });
+
+  it("passes viewKey as ?viewKey= query param", () => {
+    expect(
+      buildFormstrResponsesUrl({ naddr: SAMPLE_NADDR, viewKey: "a/b" }),
+    ).toBe(`https://formstr.app/s/${SAMPLE_NADDR}?viewKey=a%2Fb`);
   });
 });
 

--- a/src/utils/formLink.ts
+++ b/src/utils/formLink.ts
@@ -128,6 +128,20 @@ export function buildFormstrUrl(form: IFormAttachment): string {
 }
 
 /**
+ * Builds the Formstr-hosted responses URL for a form attachment.
+ *
+ * Formstr's current responses route accepts the form `naddr` directly at
+ * `/s/:naddr`. If we have a view key, pass it through using Formstr's
+ * supported `viewKey` query parameter so encrypted form metadata can still
+ * be opened by the Formstr app.
+ */
+export function buildFormstrResponsesUrl(form: IFormAttachment): string {
+  const base = `https://formstr.app/s/${form.naddr}`;
+  if (!form.viewKey) return base;
+  return `${base}?viewKey=${encodeURIComponent(form.viewKey)}`;
+}
+
+/**
  * Decodes an `naddr` to its NIP-01 replaceable-event coordinate string
  * `<kind>:<pubkey>:<dtag>` used for `#a` filter lookups (NIP-101 form
  * responses tag the source form with this coordinate).

--- a/src/utils/formLink.ts
+++ b/src/utils/formLink.ts
@@ -126,3 +126,36 @@ export function buildFormstrUrl(form: IFormAttachment): string {
   if (!form.viewKey) return base;
   return `${base}?viewKey=${encodeURIComponent(form.viewKey)}`;
 }
+
+/**
+ * Decodes an `naddr` to its NIP-01 replaceable-event coordinate string
+ * `<kind>:<pubkey>:<dtag>` used for `#a` filter lookups (NIP-101 form
+ * responses tag the source form with this coordinate).
+ *
+ * Returns null if the input is not a valid naddr.
+ */
+export function getFormCoordinate(naddr: string): string | null {
+  try {
+    const decoded = nip19.decode(naddr);
+    if (decoded.type !== "naddr") return null;
+    const { kind, pubkey, identifier } = decoded.data;
+    return `${kind}:${pubkey}:${identifier}`;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Returns the relay hints encoded inside a form `naddr`, if any.
+ * Useful so response-lookup queries reach the same relays that the
+ * form template lives on.
+ */
+export function getFormRelayHints(naddr: string): string[] {
+  try {
+    const decoded = nip19.decode(naddr);
+    if (decoded.type !== "naddr") return [];
+    return decoded.data.relays ?? [];
+  } catch {
+    return [];
+  }
+}

--- a/src/utils/formLink.ts
+++ b/src/utils/formLink.ts
@@ -33,6 +33,11 @@ const NADDR_REGEX = /naddr1[0-9a-z]+/i;
 const NKEYS_REGEX = /nkeys1[0-9a-z]+/i;
 const VIEW_KEY_REGEX = /[?&]viewKey=([^&#\s]+)/i;
 
+export type FormAddress = {
+  coordinate: string;
+  relayHints: string[];
+};
+
 /**
  * Extracts an `naddr` from arbitrary user input.
  *
@@ -142,6 +147,25 @@ export function buildFormstrResponsesUrl(form: IFormAttachment): string {
 }
 
 /**
+ * Decodes a form `naddr` into both pieces we need from the address:
+ * the NIP-01 replaceable-event coordinate used for `#a` filters and
+ * the relay hints embedded in the same naddr.
+ */
+export function getFormAddress(naddr: string): FormAddress | null {
+  try {
+    const decoded = nip19.decode(naddr);
+    if (decoded.type !== "naddr") return null;
+    const { kind, pubkey, identifier } = decoded.data;
+    return {
+      coordinate: `${kind}:${pubkey}:${identifier}`,
+      relayHints: decoded.data.relays ?? [],
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Decodes an `naddr` to its NIP-01 replaceable-event coordinate string
  * `<kind>:<pubkey>:<dtag>` used for `#a` filter lookups (NIP-101 form
  * responses tag the source form with this coordinate).
@@ -149,14 +173,7 @@ export function buildFormstrResponsesUrl(form: IFormAttachment): string {
  * Returns null if the input is not a valid naddr.
  */
 export function getFormCoordinate(naddr: string): string | null {
-  try {
-    const decoded = nip19.decode(naddr);
-    if (decoded.type !== "naddr") return null;
-    const { kind, pubkey, identifier } = decoded.data;
-    return `${kind}:${pubkey}:${identifier}`;
-  } catch {
-    return null;
-  }
+  return getFormAddress(naddr)?.coordinate ?? null;
 }
 
 /**
@@ -165,11 +182,5 @@ export function getFormCoordinate(naddr: string): string | null {
  * form template lives on.
  */
 export function getFormRelayHints(naddr: string): string[] {
-  try {
-    const decoded = nip19.decode(naddr);
-    if (decoded.type !== "naddr") return [];
-    return decoded.data.relays ?? [];
-  } catch {
-    return [];
-  }
+  return getFormAddress(naddr)?.relayHints ?? [];
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -44,10 +44,11 @@ export type NotificationPreference = "enabled" | "disabled";
  * The naddr is the Nostr address (NIP-19) of the form.
  *
  * The optional viewKey is the form's read-only NIP-44 decryption key —
- * the same value Formstr surfaces in shareable links as `?viewKey=<hex>`.
- * It must NEVER be confused with the form's `responseKey` (a.k.a. admin /
- * edit key), which grants write access to the form definition itself and
- * must never be embedded in shared calendar events.
+ * the same value Formstr surfaces in shareable links as `?viewKey=<hex>`
+ * or inside an `#nkeys1...` bech32-TLV blob. It must NEVER be confused
+ * with the form's `responseKey` (a.k.a. admin / edit key), which grants
+ * write access to the form definition itself and must never be embedded
+ * in shared calendar events.
  */
 export interface IFormAttachment {
   naddr: string;


### PR DESCRIPTION
## Description

Two independent capabilities that share the relay-query infrastructure:

1. **Relay-backed form submission detection** — `useFormSubmissionStatus` hook queries the relay for an existing kind-1069 response so the UI can show "already submitted" without the user re-entering the form.
A `sessionStorage` fallback handles relay lag after an in-app submit.

2. **Owner-only form responses viewer** — `FormResponsesDialog` lets the event author see all submitted responses (decrypted with the viewKey).



