### PR TITLE
fix: add error handling for private event decryption

### DIFF
--- a/src/common/nostr.ts
+++ b/src/common/nostr.ts
@@ -37,6 +37,7 @@ import {
   nostrEventToBusyList,
 } from "../utils/parser";
 import type { IBusyList } from "../utils/types";
+import { createLogger } from "../utils/logger";
 
 export const defaultRelays = [
   "wss://relay.damus.io/",
@@ -47,6 +48,8 @@ export const defaultRelays = [
   "wss://relay.snort.social",
   "wss://nostr21.com",
 ];
+
+const logger = createLogger("NOSTR_CORE");
 
 const _onAcceptedRelays = console.log.bind(
   console,
@@ -178,16 +181,16 @@ export async function publishPrivateCalendarEvent(
     onRelayComplete,
     existingDTag,
     invitationGiftWrapTags = [],
-    waitForAll = true
+    waitForAll = true,
   }: {
-    onAcceptedRelays?: (url: string) => void; 
+    onAcceptedRelays?: (url: string) => void;
     onRelayComplete?: (url: string, success: boolean) => void;
     /** Optional pre-generated d-tag (e.g. from a booking request) */
     existingDTag?: string;
     /** Optional public tags to place on the invitation gift wraps. */
     invitationGiftWrapTags?: string[][];
-    waitForAll?: boolean,
-  }
+    waitForAll?: boolean;
+  },
 ) {
   const viewSecretKey = generateSecretKey();
   const dTag =
@@ -480,15 +483,20 @@ export const fetchAndDecryptPrivateRSVPEvents = (
 
 export function viewPrivateEvent(calendarEvent: Event, viewKey: string) {
   const viewPrivateKey = nip19.decode(viewKey as NSec).data;
-  const decryptedContent = nip44.decrypt(
-    calendarEvent.content,
-    nip44.getConversationKey(viewPrivateKey, getPublicKey(viewPrivateKey)),
-  );
+  try {
+    const decryptedContent = nip44.decrypt(
+      calendarEvent.content,
+      nip44.getConversationKey(viewPrivateKey, getPublicKey(viewPrivateKey)),
+    );
 
-  return {
-    ...calendarEvent,
-    tags: JSON.parse(decryptedContent),
-  }; // Return the decrypted event details
+    return {
+      ...calendarEvent,
+      tags: JSON.parse(decryptedContent),
+    }; // Return the decrypted event details
+  } catch (error) {
+    logger.error("Could not decrypt event", calendarEvent, viewKey, error);
+  }
+  return null;
 }
 
 /**

--- a/src/components/DuplicateEventPage.tsx
+++ b/src/components/DuplicateEventPage.tsx
@@ -38,6 +38,7 @@ export const DuplicateEventPage = () => {
         let parsedEvent: ICalendarEvent;
         if (viewKey) {
           const privateEvent = viewPrivateEvent(event, viewKey);
+          if (!privateEvent) throw new Error("Failed to decrypt event");
           parsedEvent = nostrEventToCalendar(privateEvent, {
             viewKey,
             isPrivateEvent: true,

--- a/src/components/EditEventPage.tsx
+++ b/src/components/EditEventPage.tsx
@@ -36,6 +36,7 @@ export const EditEventPage = () => {
         let parsedEvent: ICalendarEvent;
         if (viewKey) {
           const privateEvent = viewPrivateEvent(event, viewKey);
+          if (!privateEvent) throw new Error("Failed to decrypt event");
           parsedEvent = nostrEventToCalendar(privateEvent, {
             viewKey,
             isPrivateEvent: true,

--- a/src/components/ViewEventPage.tsx
+++ b/src/components/ViewEventPage.tsx
@@ -75,6 +75,7 @@ export const ViewEventPage = () => {
         let parsedEvent: ICalendarEvent;
         if (viewKey) {
           const privateEvent = viewPrivateEvent(event, viewKey);
+          if (!privateEvent) throw new Error("Failed to decrypt event");
           parsedEvent = nostrEventToCalendar(privateEvent, {
             viewKey,
             isPrivateEvent: true,

--- a/src/stores/events.ts
+++ b/src/stores/events.ts
@@ -390,13 +390,15 @@ export const useTimeBasedEvents = create<{
         if (meta) {
           if (meta.viewKey) {
             const decrypted = viewPrivateEvent(event, meta.viewKey);
-            processPrivateEvent(
-              decrypted,
-              timeRange,
-              meta.viewKey,
-              meta.calendarId,
-              meta.relayUrl,
-            );
+            if (decrypted) {
+              processPrivateEvent(
+                decrypted,
+                timeRange,
+                meta.viewKey,
+                meta.calendarId,
+                meta.relayUrl,
+              );
+            }
           }
           processedEventIds.add(dTag);
         }

--- a/src/stores/invitations.ts
+++ b/src/stores/invitations.ts
@@ -158,6 +158,7 @@ export const useInvitations = create<InvitationsState>((set, get) => ({
           const invitation = batch.find((inv) => inv.eventId === eventId);
           if (!invitation) return;
           const decrypted = viewPrivateEvent(event, invitation.viewKey);
+          if (!decrypted) return;
           const parsed = nostrEventToCalendar(decrypted, {
             viewKey: invitation.viewKey,
             isPrivateEvent: true,


### PR DESCRIPTION
- Wrap viewPrivateEvent decryption logic in try-catch block to gracefully handle decryption failures
- Return null instead of throwing when decryption fails
- Add logger to capture decryption errors with event details for debugging
- Update event processing in stores to check for null before processing decrypted events

This prevents crashes when attempting to decrypt malformed or incompatible private calendar events and provides better observability for decryption issues.