### PR TITLE
fix: send gift wraps to newly added participants when editing events

### DIFF
--- a/src/common/nostr.ts
+++ b/src/common/nostr.ts
@@ -277,6 +277,7 @@ export async function publishPrivateCalendarEvent(
 export async function editPrivateCalendarEvent(
   event: ICalendarEvent,
   calendarId: string,
+  previousParticipants: string[] = [],
   onAcceptedRelays?: (url: string) => void,
   onRelayComplete?: (url: string, success: boolean) => void,
 ) {
@@ -285,10 +286,53 @@ export async function editPrivateCalendarEvent(
   const { signedEvent, eventKind, userPublicKey } =
     await preparePrivateCalendarEvent(event, dTag, viewSecretKey);
 
-  await publishToRelays(signedEvent, onAcceptedRelays, undefined, {
-    waitForAll: true,
-    onRelayComplete,
-  });
+  let publishedRelayHint = "";
+  await publishToRelays(
+    signedEvent,
+    (url) => {
+      if (!publishedRelayHint) publishedRelayHint = url;
+      onAcceptedRelays?.(url);
+    },
+    undefined,
+    { waitForAll: true, onRelayComplete },
+  );
+
+  // Send gift wraps to participants that weren't in the previous version.
+  const previousSet = new Set(previousParticipants);
+  const newParticipants = event.participants.filter((p) => !previousSet.has(p));
+  if (newParticipants.length > 0) {
+    const [participantRelayMap, ...giftWraps] = await Promise.all([
+      fetchRelayLists(newParticipants),
+      ...newParticipants.map(async (participant) => {
+        const giftWrap = await nip59.wrapEvent(
+          {
+            pubkey: userPublicKey,
+            created_at: Math.floor(Date.now() / 1000),
+            kind: EventKinds.CalendarEventRumor,
+            content: "",
+            tags: [
+              [
+                "a",
+                `${eventKind}:${userPublicKey}:${dTag}`,
+                publishedRelayHint,
+              ],
+              ["viewKey", nip19.nsecEncode(viewSecretKey)],
+            ],
+          },
+          participant,
+          EventKinds.CalendarEventGiftWrap,
+        );
+        return { giftWrap, participant };
+      }),
+    ]);
+    await Promise.all(
+      giftWraps.map(async ({ giftWrap, participant }) => {
+        const relays = participantRelayMap.get(participant) ?? defaultRelays;
+        console.log(`Publishing invitation for ${participant} to ${relays}`);
+        await publishToRelays(giftWrap, undefined, relays);
+      }),
+    );
+  }
 
   const eventCoordinate = `${eventKind}:${userPublicKey}:${dTag}`;
   const eventRef = buildEventRef({

--- a/src/components/CalendarEventEdit.tsx
+++ b/src/components/CalendarEventEdit.tsx
@@ -467,6 +467,7 @@ export function CalendarEventEdit({
           const updates = await editPrivateCalendarEvent(
             eventToSave,
             selectedCalendarId,
+            initialEvent?.participants ?? [],
             undefined,
             onRelayComplete,
           );


### PR DESCRIPTION
editPrivateCalendarEvent was publishing the updated event with new
participant pubkeys in "p" tags but never creating or sending gift wrap
invitations to those participants. They had no way to discover the event
through the invitations system.

The fix computes the diff between previousParticipants and the current
list, then creates and publishes NIP-59 gift wraps for each new participant
(mirroring the existing logic in publishPrivateCalendarEvent). The call
site passes initialEvent.participants as the previous set so only truly
new participants receive a wrap.

https://claude.ai/code/session_01YS2u6Ur7Hd2nTKYnjEDZyA