### PR TITLE
Revoke access when a participant is removed from an event

### DIFF
--- a/src/common/calendarList.ts
+++ b/src/common/calendarList.ts
@@ -34,6 +34,7 @@ import type { ICalendarList } from "../utils/calendarListTypes";
 import {
   DEFAULT_CALENDAR_COLOR,
   DEFAULT_CALENDAR_TITLE,
+  replaceEventRefViewKey,
 } from "../utils/calendarListTypes";
 import type { SubscriptionHandle } from "./nostrRuntime";
 
@@ -305,6 +306,48 @@ export async function removeEventFromCalendarList(
   const updated: ICalendarList = {
     ...calendarList,
     eventRefs: calendarList.eventRefs.filter((ref) => ref[0] !== eventRef[0]),
+    createdAt: Math.floor(Date.now() / 1000),
+  };
+
+  await publishCalendarList(updated);
+  return updated;
+}
+
+/**
+ * Replaces the view key (and optionally relay hint) of an event reference
+ * inside a calendar list, then republishes the list.
+ *
+ * Unlike {@link addEventToCalendarList}, this targets a ref that already
+ * exists by coordinate — the add/move helpers dedupe by coordinate and would
+ * treat a same-coordinate/new-key ref as a no-op, so key rotation and access
+ * updates need this dedicated path. If no ref matches the coordinate, the list
+ * is returned unchanged and nothing is published.
+ *
+ * @param calendarList - The calendar list to update
+ * @param eventCoordinate - Coordinate "{kind}:{authorPubkey}:{eventDTag}"
+ * @param newViewKey - The nsec-encoded view key to store
+ * @param relayUrl - Optional relay hint to update alongside the key
+ * @returns The updated (and published) calendar list, or the original if unchanged
+ */
+export async function updateEventRefViewKey(
+  calendarList: ICalendarList,
+  eventCoordinate: string,
+  newViewKey: string,
+  relayUrl?: string,
+): Promise<ICalendarList> {
+  const hasRef = calendarList.eventRefs.some(
+    (ref) => ref[0] === eventCoordinate,
+  );
+  if (!hasRef) return calendarList;
+
+  const updated: ICalendarList = {
+    ...calendarList,
+    eventRefs: replaceEventRefViewKey(
+      calendarList.eventRefs,
+      eventCoordinate,
+      newViewKey,
+      relayUrl,
+    ),
     createdAt: Math.floor(Date.now() / 1000),
   };
 

--- a/src/common/dictionary.ts
+++ b/src/common/dictionary.ts
@@ -37,6 +37,7 @@ const dictionary: NestedObject = {
       privateEventCaption:
         "Private events are only visible to you and the invited participants",
       relays: "Relays",
+      eventsWithoutAccess: "Events without access",
       goToWeek: "go to week",
     },
     filters: {
@@ -266,6 +267,34 @@ const dictionary: NestedObject = {
       addedToCalendar: "Event added to your calendar",
       viewInCalendar: "View in Calendar",
       stayHere: "Stay Here",
+      accessUpdated:
+        "{participant} updated your access to this event. Update your calendar to see the latest version.",
+      noAccess:
+        "Invited by {participant}. You don't have access yet — please ask them to provide you access.",
+      updateMyCalendar: "Update my calendar",
+    },
+    rotateKey: {
+      action: "Rotate access key",
+      title: "Rotate access key",
+      warning:
+        "Rotating generates a new key and re-encrypts this event. Anyone who has the old key — including people you shared a link with — will lose access to it.",
+      shareQuestion: "Who should receive the new key?",
+      invitedOnly: "Invited participants",
+      invitedOnlyCount:
+        "{count, plural, one {# participant} other {# participants}}",
+      invitedAndResponders: "Invited participants and people who RSVP'd",
+      invitedAndRespondersCount:
+        "{count, plural, one {# person} other {# people}}",
+      rotate: "Rotate key",
+      rotating: "Rotating…",
+      error: "Could not rotate the key. Please try again.",
+    },
+    eventsWithoutAccess: {
+      title: "Events Without Access",
+      empty: "No events are missing access.",
+      invitedBy:
+        "{dTag} invited by {participant}. Please ask them to provide you access.",
+      remove: "Remove from my calendar",
     },
     login: {
       signInToFormstr: "Sign in to Formstr",

--- a/src/common/dictionary.ts
+++ b/src/common/dictionary.ts
@@ -129,6 +129,8 @@ const dictionary: NestedObject = {
       notInCalendar:
         "This event is not in any of your calendars. You will not receive notifications for this event. Add it to your calendar to receive notifications.",
       scheduledNotifications: "Scheduled Notifications",
+      removeParticipantWarning:
+        "Removing a participant rotates this event's key. The removed person loses access, and the remaining participants are re-invited with the new key.",
     },
     form: {
       attachments: "Forms",

--- a/src/common/nostr.ts
+++ b/src/common/nostr.ts
@@ -28,7 +28,10 @@ import { EventKinds } from "./EventConfigs";
 import { nostrRuntime } from "./nostrRuntime";
 import { useRelayStore } from "../stores/relays";
 import { useCalendarLists } from "../stores/calendarLists";
-import { buildEventRef } from "../utils/calendarListTypes";
+import {
+  buildEventRef,
+  resolveRotationRecipients,
+} from "../utils/calendarListTypes";
 import { sha256 } from "@noble/hashes/sha2.js";
 import { bytesToHex, utf8ToBytes } from "@noble/hashes/utils.js";
 import {
@@ -584,6 +587,115 @@ export async function editPrivateCalendarEvent(
     event,
     calendarId,
     signedEvent,
+  };
+}
+
+/**
+ * Rotates the view key of an existing private calendar event so the author can
+ * regain control after the key (or a shared `?viewKey=` link) leaked.
+ *
+ * Mechanism (NIP-52E "Security Considerations"): the event keeps the same
+ * d-tag, so every participant's calendar reference stays valid. The content is
+ * re-encrypted under a freshly generated view key and republished — anyone
+ * still holding the old key can no longer decrypt the current/future version.
+ * The new key is gift-wrapped only to the chosen recipients, and the author's
+ * own calendar reference is updated in place.
+ *
+ * @param event - The private event to re-key (must be authored by the user)
+ * @param calendarId - The calendar list holding the author's reference to it
+ * @param recipientPubkeys - Final set of pubkeys to receive the new key
+ *   (the caller decides "invited" vs "invited + RSVP responders"); the
+ *   author's own pubkey is excluded automatically.
+ */
+export async function rotatePrivateEventKey(
+  event: ICalendarEvent,
+  calendarId: string,
+  recipientPubkeys: string[],
+  {
+    onAcceptedRelays,
+    onRelayComplete,
+  }: {
+    onAcceptedRelays?: (url: string) => void;
+    onRelayComplete?: (url: string, success: boolean) => void;
+  } = {},
+) {
+  const dTag = event.id;
+  const newViewSecretKey = generateSecretKey();
+  const newViewKeyNsec = nip19.nsecEncode(newViewSecretKey);
+
+  // Re-encrypt the same content under the new key and republish (same d-tag).
+  const { signedEvent, eventKind, userPublicKey } =
+    await preparePrivateCalendarEvent(event, dTag, newViewSecretKey);
+
+  let publishedRelayHint = "";
+  await publishToRelays(
+    signedEvent,
+    (url) => {
+      if (!publishedRelayHint) publishedRelayHint = url;
+      onAcceptedRelays?.(url);
+    },
+    undefined,
+    { waitForAll: true, onRelayComplete },
+  );
+
+  // Resolve recipients (excluding self) and gift-wrap the new key to each,
+  // published to the recipient's own relays.
+  const recipients = resolveRotationRecipients({
+    invitedParticipants: recipientPubkeys,
+    rsvpResponders: [],
+    includeRsvpResponders: false,
+    selfPubkey: userPublicKey,
+  });
+
+  if (recipients.length > 0) {
+    const [participantRelayMap, ...giftWraps] = await Promise.all([
+      fetchRelayLists(recipients),
+      ...recipients.map(async (participant) => {
+        const giftWrap = await nip59.wrapEvent(
+          {
+            pubkey: userPublicKey,
+            created_at: Math.floor(Date.now() / 1000),
+            kind: EventKinds.CalendarEventRumor,
+            content: "",
+            tags: [
+              [
+                "a",
+                `${eventKind}:${userPublicKey}:${dTag}`,
+                publishedRelayHint,
+              ],
+              ["viewKey", newViewKeyNsec],
+            ],
+          },
+          participant,
+          EventKinds.CalendarEventGiftWrap,
+        );
+        return { giftWrap, participant };
+      }),
+    ]);
+    await Promise.all(
+      giftWraps.map(async ({ giftWrap, participant }) => {
+        const relays = participantRelayMap.get(participant) ?? defaultRelays;
+        await publishToRelays(giftWrap, undefined, relays);
+      }),
+    );
+  }
+
+  // Update the author's own calendar reference with the new key in place.
+  const eventCoordinate = `${eventKind}:${userPublicKey}:${dTag}`;
+  await useCalendarLists
+    .getState()
+    .updateEventRefViewKey(
+      calendarId,
+      eventCoordinate,
+      newViewKeyNsec,
+      event.relayHint || publishedRelayHint,
+    );
+
+  return {
+    viewKey: newViewKeyNsec,
+    signedEvent,
+    recipients,
+    relayHint: event.relayHint || publishedRelayHint,
   };
 }
 

--- a/src/common/nostr.ts
+++ b/src/common/nostr.ts
@@ -31,6 +31,8 @@ import { useCalendarLists } from "../stores/calendarLists";
 import {
   buildEventRef,
   resolveRotationRecipients,
+  getRemovedParticipants,
+  resolveRemovalRekeyRecipients,
 } from "../utils/calendarListTypes";
 import { sha256 } from "@noble/hashes/sha2.js";
 import { bytesToHex, utf8ToBytes } from "@noble/hashes/utils.js";
@@ -507,6 +509,24 @@ export async function publishPrivateCalendarEvent(
   };
 }
 
+/**
+ * Returns the distinct pubkeys that have published a private RSVP (kind 32069)
+ * for the given event coordinate. The responder's identity is the RSVP event's
+ * author (plaintext), so no view key or decryption is needed — we only care
+ * *who* responded, which is enough to keep them in the loop on a key rotation.
+ */
+export async function fetchPrivateRSVPResponderPubkeys(
+  eventCoord: string,
+  relayHint?: string,
+): Promise<string[]> {
+  const relays = getDiscoveryRelays(relayHint ? [relayHint] : []);
+  const events = await nostrRuntime.querySync(relays, {
+    kinds: [EventKinds.PrivateRSVPEvent],
+    "#a": [eventCoord],
+  });
+  return [...new Set(events.map((event) => event.pubkey))];
+}
+
 export async function editPrivateCalendarEvent(
   event: ICalendarEvent,
   calendarId: string,
@@ -515,9 +535,67 @@ export async function editPrivateCalendarEvent(
   onRelayComplete?: (url: string, success: boolean) => void,
 ) {
   const dTag = event.id;
+  const userPublicKey = await getUserPublicKey();
+  const eventKind = EventKinds.PrivateCalendarEvent;
+  const eventCoordinate = `${eventKind}:${userPublicKey}:${dTag}`;
+
+  // Removing a participant must actually revoke their access — republishing
+  // under the same key leaves them able to decrypt and keep receiving updates.
+  // When a removal is detected, rotate the key and re-share it with everyone
+  // who should keep access (remaining invited participants + RSVP responders,
+  // e.g. link invitees), minus the removed person(s).
+  const removedParticipants = getRemovedParticipants(
+    previousParticipants,
+    event.participants,
+    userPublicKey,
+  );
+
+  if (removedParticipants.length > 0) {
+    const responders = await fetchPrivateRSVPResponderPubkeys(
+      eventCoordinate,
+      event.relayHint,
+    );
+    const recipients = resolveRemovalRekeyRecipients({
+      remainingParticipants: event.participants,
+      rsvpResponders: responders,
+      removedParticipants,
+      selfPubkey: userPublicKey,
+    });
+
+    // If this edit also moved the event to a different calendar, relocate the
+    // reference (with the current key) first so the in-place key update inside
+    // rotatePrivateEventKey lands on the target calendar. No-op if unchanged.
+    const currentRef = buildEventRef({
+      kind: eventKind,
+      authorPubkey: userPublicKey,
+      eventDTag: dTag,
+      relayUrl: event.relayHint ?? "",
+      viewKey: event.viewKey ?? "",
+    });
+    await useCalendarLists
+      .getState()
+      .moveEventToCalendar(calendarId, eventCoordinate, currentRef);
+
+    const { viewKey, signedEvent } = await rotatePrivateEventKey(
+      event,
+      calendarId,
+      recipients,
+      { onAcceptedRelays, onRelayComplete },
+    );
+
+    return {
+      event: { ...event, viewKey },
+      calendarId,
+      signedEvent,
+    };
+  }
+
   const viewSecretKey = nip19.decode(event.viewKey as NSec).data;
-  const { signedEvent, eventKind, userPublicKey } =
-    await preparePrivateCalendarEvent(event, dTag, viewSecretKey);
+  const { signedEvent } = await preparePrivateCalendarEvent(
+    event,
+    dTag,
+    viewSecretKey,
+  );
 
   let publishedRelayHint = "";
   await publishToRelays(
@@ -567,7 +645,6 @@ export async function editPrivateCalendarEvent(
     );
   }
 
-  const eventCoordinate = `${eventKind}:${userPublicKey}:${dTag}`;
   // Preserve the relay hint from the existing event so the updated ref still
   // points to the relay where the event lives.  Without this the relay URL is
   // dropped on every edit, making subsequent fetches miss the event.

--- a/src/components/Auth.tsx
+++ b/src/components/Auth.tsx
@@ -2,8 +2,10 @@ import { MenuItem } from "@mui/material";
 import { useUser } from "../stores/user";
 import { useIntl } from "react-intl";
 import { useEffect } from "react";
+import { useNavigate } from "react-router";
 import { npubEncode } from "nostr-tools/nip19";
 import { useRelayStore } from "../stores/relays";
+import { ROUTES } from "../utils/routingHelper";
 
 export const Auth = () => {
   const { user, updateLoginModal, logout, initializeUser } = useUser(
@@ -11,6 +13,7 @@ export const Auth = () => {
   );
   const hasUserLoggedIn = !!user;
   const intl = useIntl();
+  const navigate = useNavigate();
 
   useEffect(() => {
     initializeUser();
@@ -45,10 +48,17 @@ export const Auth = () => {
     useRelayStore.getState().updateRelayModal(true);
   };
 
+  const handleOpenEventsWithoutAccess = () => {
+    navigate(ROUTES.EventsWithoutAccess);
+  };
+
   const logoutElem = (
     <>
       <MenuItem onClick={handleOpenRelays}>
         {intl.formatMessage({ id: "navigation.relays" })}
+      </MenuItem>
+      <MenuItem onClick={handleOpenEventsWithoutAccess}>
+        {intl.formatMessage({ id: "navigation.eventsWithoutAccess" })}
       </MenuItem>
       <MenuItem onClick={handleLogout}>
         {intl.formatMessage({ id: "navigation.logout" })}

--- a/src/components/CalendarEvent.tsx
+++ b/src/components/CalendarEvent.tsx
@@ -29,6 +29,7 @@ import Download from "@mui/icons-material/Download";
 import Edit from "@mui/icons-material/Edit";
 import FileCopy from "@mui/icons-material/FileCopy";
 import Delete from "@mui/icons-material/Delete";
+import VpnKey from "@mui/icons-material/VpnKey";
 import NotificationsActiveIcon from "@mui/icons-material/NotificationsActive";
 import PhoneAndroidIcon from "@mui/icons-material/PhoneAndroid";
 import dayjs from "dayjs";
@@ -53,6 +54,7 @@ import {
 import { useIntl, type IntlShape } from "react-intl";
 import { useUser } from "../stores/user";
 import { DeleteEventDialog } from "./DeleteEventDialog";
+import { RotateKeyDialog } from "./RotateKeyDialog";
 import { EventBusyListToggle } from "./EventBusyListToggle";
 
 import {
@@ -337,8 +339,10 @@ function ActionButtons({
 }) {
   const intl = useIntl();
   const { user } = useUser();
+  const { calendars } = useCalendarLists();
   const navigate = useNavigate();
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [rotateDialogOpen, setRotateDialogOpen] = useState(false);
   const iconSize = isMobile ? "small" : "medium";
 
   // Device events have no Nostr coordinate; render a slim action bar that
@@ -389,6 +393,12 @@ function ActionButtons({
     navigator.clipboard.writeText(eventUrl);
   };
   const isEditable = event.user === user?.pubkey;
+  // Rotation needs the event in one of the author's calendars (we rewrite the
+  // stored view key there). Only private events have a key to rotate.
+  const rotateCalendar = event.isPrivateEvent
+    ? findCalendarForEvent(calendars, event)
+    : undefined;
+  const canRotateKey = isEditable && !!rotateCalendar;
 
   const editEvent = () => {
     const editLink = getEditEventPage(
@@ -469,6 +479,13 @@ function ActionButtons({
           </Tooltip>
         </IconButton>
       )}
+      {canRotateKey && (
+        <IconButton size={iconSize} onClick={() => setRotateDialogOpen(true)}>
+          <Tooltip title={intl.formatMessage({ id: "rotateKey.action" })}>
+            <VpnKey fontSize={iconSize} />
+          </Tooltip>
+        </IconButton>
+      )}
       <IconButton size={iconSize} onClick={() => setDeleteDialogOpen(true)}>
         <Tooltip title={intl.formatMessage({ id: "event.deleteEvent" })}>
           <Delete fontSize={iconSize} />
@@ -482,6 +499,14 @@ function ActionButtons({
         }}
         event={event}
       />
+      {canRotateKey && rotateCalendar && (
+        <RotateKeyDialog
+          open={rotateDialogOpen}
+          onClose={() => setRotateDialogOpen(false)}
+          event={event}
+          calendarId={rotateCalendar.id}
+        />
+      )}
       {showClose && (
         <IconButton
           size={iconSize}

--- a/src/components/CalendarEventEdit.tsx
+++ b/src/components/CalendarEventEdit.tsx
@@ -19,6 +19,7 @@ import {
   useTheme,
   Checkbox,
   FormControlLabel,
+  Alert,
 } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
 import { ICalendarEvent, RepeatingFrequency } from "../utils/types";
@@ -60,6 +61,7 @@ import { useUser } from "../stores/user";
 import {
   findCalendarForEvent,
   parseEventRef,
+  getRemovedParticipants,
 } from "../utils/calendarListTypes";
 import { isBusyListRangeSupportedForEvent } from "../utils/busyList";
 import { CalendarListSelect } from "./CalendarListSelect";
@@ -428,6 +430,16 @@ export function CalendarEventEdit({
     user?.pubkey,
   );
   const displayParticipants = uniqueParticipants(eventDetails.participants);
+  // Removing a participant from a private event rotates the view key on save
+  // (so the removed person loses access). Warn the author when that will happen.
+  const removedParticipants =
+    mode === "edit" && initialEvent && isPrivate
+      ? getRemovedParticipants(
+          initialEvent.participants,
+          eventDetails.participants,
+          user?.pubkey ?? "",
+        )
+      : [];
   const [formInput, setFormInput] = useState("");
   const [formInputError, setFormInputError] = useState<string | null>(null);
 
@@ -1276,6 +1288,12 @@ export function CalendarEventEdit({
                 </Box>
               ))}
             </Box>
+          )}
+
+          {removedParticipants.length > 0 && (
+            <Alert severity="warning">
+              {intl.formatMessage({ id: "event.removeParticipantWarning" })}
+            </Alert>
           )}
         </Box>
       </Box>

--- a/src/components/EventsWithoutAccessPage.tsx
+++ b/src/components/EventsWithoutAccessPage.tsx
@@ -1,0 +1,123 @@
+/**
+ * Events Without Access Page
+ *
+ * Lists private events the client knows about (they're referenced in a
+ * calendar list) but cannot decrypt — usually because the author rotated the
+ * view key and hasn't re-shared it with this user yet.
+ *
+ * For each event the user can either ask the author for access (the author is
+ * shown via their profile) or remove the dangling reference from their
+ * calendar.
+ */
+
+import { useEffect } from "react";
+import {
+  Box,
+  Typography,
+  Button,
+  Paper,
+  IconButton,
+  useTheme,
+  useMediaQuery,
+} from "@mui/material";
+import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import { useNavigate } from "react-router";
+import { FormattedMessage, useIntl } from "react-intl";
+import { useInaccessibleEvents } from "../stores/inaccessibleEvents";
+import { useCalendarLists } from "../stores/calendarLists";
+import { useTimeBasedEvents } from "../stores/events";
+import { Participant } from "./Participant";
+
+export function EventsWithoutAccessPage() {
+  const intl = useIntl();
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
+  const navigate = useNavigate();
+  const { byCoordinate, remove } = useInaccessibleEvents();
+  const { removeEventFromCalendar } = useCalendarLists();
+  const { removeEvent } = useTimeBasedEvents();
+
+  // Surface the freshest snapshot when re-entering the page.
+  useEffect(() => {
+    void useCalendarLists.getState().fetchCalendars();
+  }, []);
+
+  const events = Object.values(byCoordinate).sort(
+    (a, b) => b.lastSeenAt - a.lastSeenAt,
+  );
+
+  const handleRemove = async (coordinate: string) => {
+    const entry = byCoordinate[coordinate];
+    if (!entry) return;
+    // Drop the dangling reference from the calendar list (republishes it),
+    // then clear local traces of the event.
+    await removeEventFromCalendar(entry.calendarId, [coordinate]);
+    removeEvent(entry.dTag);
+    remove(coordinate);
+  };
+
+  return (
+    <Box p={2} maxWidth={isMobile ? "100%" : 600} mx="auto">
+      <Box display="flex" alignItems="center" gap={1} mb={3}>
+        <IconButton onClick={() => navigate(-1)}>
+          <ArrowBackIcon />
+        </IconButton>
+        <Typography variant="h5" fontWeight={600}>
+          {intl.formatMessage({ id: "eventsWithoutAccess.title" })}
+        </Typography>
+        {events.length > 0 && (
+          <Typography variant="body2" color="text.secondary">
+            ({events.length})
+          </Typography>
+        )}
+      </Box>
+
+      {events.length === 0 && (
+        <Box py={4} textAlign="center">
+          <Typography variant="body1" color="text.secondary">
+            {intl.formatMessage({ id: "eventsWithoutAccess.empty" })}
+          </Typography>
+        </Box>
+      )}
+
+      {events.map((entry) => (
+        <Paper
+          key={entry.coordinate}
+          sx={{
+            mb: 2,
+            p: 2,
+            backgroundColor: "#e0e0e0",
+            border: "2px dashed #999",
+            borderRadius: 2,
+          }}
+        >
+          <Box display="flex" alignItems="center" flexWrap="wrap" gap={0.5}>
+            <FormattedMessage
+              id="eventsWithoutAccess.invitedBy"
+              values={{
+                dTag: (
+                  <Typography component="span" fontWeight={600}>
+                    {entry.dTag}
+                  </Typography>
+                ),
+                participant: (
+                  <Participant pubKey={entry.authorPubkey} isAuthor={false} />
+                ),
+              }}
+            />
+          </Box>
+
+          <Box display="flex" justifyContent="flex-end" mt={2}>
+            <Button
+              size="small"
+              color="inherit"
+              onClick={() => handleRemove(entry.coordinate)}
+            >
+              {intl.formatMessage({ id: "eventsWithoutAccess.remove" })}
+            </Button>
+          </Box>
+        </Paper>
+      ))}
+    </Box>
+  );
+}

--- a/src/components/InvitationPanel.tsx
+++ b/src/components/InvitationPanel.tsx
@@ -38,7 +38,12 @@ export function InvitationPanel() {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
   const navigate = useNavigate();
-  const { invitations, acceptInvitation, dismissInvitation } = useInvitations();
+  const {
+    invitations,
+    acceptInvitation,
+    applyAccessUpdate,
+    dismissInvitation,
+  } = useInvitations();
   const { fetchCalendars } = useCalendarLists();
 
   useEffect(() => {
@@ -150,7 +155,53 @@ export function InvitationPanel() {
             borderRadius: 2,
           }}
         >
-          {invitation.event ? (
+          {invitation.isAccessUpdate ? (
+            // The author rotated this event's view key and re-shared it.
+            <Box>
+              <Typography variant="subtitle1" fontWeight={600}>
+                {invitation.event?.title || invitation.eventId}
+              </Typography>
+              {invitation.event && (
+                <TimeRenderer
+                  begin={invitation.event.begin}
+                  end={invitation.event.end}
+                  repeat={invitation.event.repeat}
+                  allDay={invitation.event.allDay}
+                />
+              )}
+              <Box
+                display="flex"
+                alignItems="center"
+                gap={0.5}
+                mt={1}
+                flexWrap="wrap"
+              >
+                <FormattedMessage
+                  id="invitation.accessUpdated"
+                  values={{
+                    participant: (
+                      <Participant
+                        pubKey={invitation.pubkey}
+                        isAuthor={false}
+                      />
+                    ),
+                  }}
+                />
+              </Box>
+            </Box>
+          ) : invitation.inaccessible ? (
+            // Could not decrypt with the key this gift wrap carried.
+            <Box display="flex" alignItems="center" gap={0.5} flexWrap="wrap">
+              <FormattedMessage
+                id="invitation.noAccess"
+                values={{
+                  participant: (
+                    <Participant pubKey={invitation.pubkey} isAuthor={false} />
+                  ),
+                }}
+              />
+            </Box>
+          ) : invitation.event ? (
             <Box>
               <Typography variant="subtitle1" fontWeight={600}>
                 {invitation.event.title}
@@ -226,16 +277,28 @@ export function InvitationPanel() {
             >
               {intl.formatMessage({ id: "invitation.dismiss" })}
             </Button>
-            <Button
-              size="small"
-              variant="contained"
-              disabled={!invitation.event?.user}
-              onClick={() =>
-                handleAccept(invitation.giftWrapId, invitation.event)
-              }
-            >
-              {intl.formatMessage({ id: "addToCalendar.addToCalendar" })}
-            </Button>
+            {invitation.isAccessUpdate ? (
+              <Button
+                size="small"
+                variant="contained"
+                onClick={() => applyAccessUpdate(invitation.giftWrapId)}
+              >
+                {intl.formatMessage({ id: "invitation.updateMyCalendar" })}
+              </Button>
+            ) : (
+              !invitation.inaccessible && (
+                <Button
+                  size="small"
+                  variant="contained"
+                  disabled={!invitation.event?.user}
+                  onClick={() =>
+                    handleAccept(invitation.giftWrapId, invitation.event)
+                  }
+                >
+                  {intl.formatMessage({ id: "addToCalendar.addToCalendar" })}
+                </Button>
+              )
+            )}
           </Box>
         </Paper>
       ))}

--- a/src/components/RotateKeyDialog.tsx
+++ b/src/components/RotateKeyDialog.tsx
@@ -1,0 +1,219 @@
+/**
+ * Rotate Key Dialog
+ *
+ * Lets the event author rotate the event's view key to regain control after
+ * the key (or a shared `?viewKey=` link) leaked. The author chooses whether
+ * the new key is re-shared with only the invited participants, or also with
+ * people who RSVP'd (who may have arrived via a shared URL).
+ *
+ * Rotating re-encrypts the event under a fresh key and republishes it, so
+ * anyone still holding the old key — including old shared links — loses access
+ * to the current and future version.
+ */
+
+import { useMemo, useState } from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Box,
+  Typography,
+  IconButton,
+  RadioGroup,
+  Radio,
+  FormControlLabel,
+  Alert,
+  useMediaQuery,
+  useTheme,
+  CircularProgress,
+} from "@mui/material";
+import CloseIcon from "@mui/icons-material/Close";
+import { useIntl } from "react-intl";
+import type { ICalendarEvent } from "../utils/types";
+import { rotatePrivateEventKey } from "../common/nostr";
+import { resolveRotationRecipients } from "../utils/calendarListTypes";
+import { useTimeBasedEvents } from "../stores/events";
+import { useUser } from "../stores/user";
+import { useEventRsvps } from "../hooks/useEventRsvps";
+
+type RotateScope = "invited" | "invitedAndResponders";
+
+interface RotateKeyDialogProps {
+  open: boolean;
+  onClose: () => void;
+  event: ICalendarEvent;
+  calendarId: string;
+}
+
+export function RotateKeyDialog({
+  open,
+  onClose,
+  event,
+  calendarId,
+}: RotateKeyDialogProps) {
+  const intl = useIntl();
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
+  const { user } = useUser();
+  const { updateEvent } = useTimeBasedEvents();
+  const { byPubkey } = useEventRsvps(event);
+
+  const [scope, setScope] = useState<RotateScope>("invited");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(false);
+
+  const selfPubkey = user?.pubkey ?? "";
+
+  // Invited participants are the event's `p` tags minus the author.
+  const invitedParticipants = useMemo(
+    () => (event.participants ?? []).filter((p) => p !== selfPubkey),
+    [event.participants, selfPubkey],
+  );
+
+  // RSVP responders that are not already invited and not the author.
+  const responderPubkeys = useMemo(
+    () => Object.keys(byPubkey).filter((p) => p !== selfPubkey),
+    [byPubkey, selfPubkey],
+  );
+  const extraResponders = useMemo(() => {
+    const invited = new Set(invitedParticipants);
+    return responderPubkeys.filter((p) => !invited.has(p));
+  }, [responderPubkeys, invitedParticipants]);
+
+  const recipients = useMemo(
+    () =>
+      resolveRotationRecipients({
+        invitedParticipants,
+        rsvpResponders: responderPubkeys,
+        includeRsvpResponders: scope === "invitedAndResponders",
+        selfPubkey,
+      }),
+    [invitedParticipants, responderPubkeys, scope, selfPubkey],
+  );
+
+  const handleRotate = async () => {
+    setLoading(true);
+    setError(false);
+    try {
+      const { viewKey, relayHint } = await rotatePrivateEventKey(
+        event,
+        calendarId,
+        recipients,
+      );
+      // Reflect the new key locally so subsequent shares/links use it.
+      updateEvent({
+        ...event,
+        viewKey,
+        relayHint: relayHint || event.relayHint,
+      });
+      onClose();
+    } catch (e) {
+      console.error("Failed to rotate event key:", e);
+      setError(true);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog
+      fullScreen={isMobile}
+      open={open}
+      onClose={loading ? undefined : onClose}
+      maxWidth="sm"
+      fullWidth
+    >
+      <DialogTitle>
+        <Box display="flex" justifyContent="space-between" alignItems="center">
+          <Typography variant="h6" fontWeight={600}>
+            {intl.formatMessage({ id: "rotateKey.title" })}
+          </Typography>
+          <IconButton onClick={onClose} size="small" disabled={loading}>
+            <CloseIcon />
+          </IconButton>
+        </Box>
+      </DialogTitle>
+
+      <DialogContent dividers>
+        <Box display="flex" flexDirection="column" gap={2}>
+          <Alert severity="warning">
+            {intl.formatMessage({ id: "rotateKey.warning" })}
+          </Alert>
+
+          <Typography variant="body2" color="text.secondary">
+            {intl.formatMessage({ id: "rotateKey.shareQuestion" })}
+          </Typography>
+
+          <RadioGroup
+            value={scope}
+            onChange={(e) => setScope(e.target.value as RotateScope)}
+          >
+            <FormControlLabel
+              value="invited"
+              control={<Radio />}
+              label={
+                <Box>
+                  <Typography fontWeight={500}>
+                    {intl.formatMessage({ id: "rotateKey.invitedOnly" })}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    {intl.formatMessage(
+                      { id: "rotateKey.invitedOnlyCount" },
+                      { count: invitedParticipants.length },
+                    )}
+                  </Typography>
+                </Box>
+              }
+            />
+            <FormControlLabel
+              value="invitedAndResponders"
+              control={<Radio />}
+              label={
+                <Box>
+                  <Typography fontWeight={500}>
+                    {intl.formatMessage({
+                      id: "rotateKey.invitedAndResponders",
+                    })}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    {intl.formatMessage(
+                      { id: "rotateKey.invitedAndRespondersCount" },
+                      {
+                        count:
+                          invitedParticipants.length + extraResponders.length,
+                      },
+                    )}
+                  </Typography>
+                </Box>
+              }
+            />
+          </RadioGroup>
+
+          {error && (
+            <Alert severity="error">
+              {intl.formatMessage({ id: "rotateKey.error" })}
+            </Alert>
+          )}
+        </Box>
+      </DialogContent>
+
+      <DialogActions sx={{ padding: 2 }}>
+        <Button onClick={onClose} color="inherit" disabled={loading}>
+          {intl.formatMessage({ id: "navigation.cancel" })}
+        </Button>
+        <Button
+          onClick={handleRotate}
+          variant="contained"
+          disabled={loading}
+          startIcon={loading ? <CircularProgress size={16} /> : undefined}
+        >
+          {loading
+            ? intl.formatMessage({ id: "rotateKey.rotating" })
+            : intl.formatMessage({ id: "rotateKey.rotate" })}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/components/Routing.tsx
+++ b/src/components/Routing.tsx
@@ -7,6 +7,7 @@ import { ROUTES } from "../utils/routingHelper";
 import { Index } from "./Index";
 import Calendar from "./Calendar";
 import { InvitationPanel } from "./InvitationPanel";
+import { EventsWithoutAccessPage } from "./EventsWithoutAccessPage";
 import { SchedulingPageEdit } from "./SchedulingPageEdit";
 import { BookingPage } from "./BookingPage";
 import { BookingNotifications } from "./BookingNotifications";
@@ -25,6 +26,10 @@ export const Routing = () => {
         element={<NotificationEventPage />}
       />
       <Route path={ROUTES.Notifications} element={<InvitationPanel />} />
+      <Route
+        path={ROUTES.EventsWithoutAccess}
+        element={<EventsWithoutAccessPage />}
+      />
       <Route
         path={ROUTES.SchedulingPageCreate}
         element={<SchedulingPageEdit />}

--- a/src/stores/calendarLists.ts
+++ b/src/stores/calendarLists.ts
@@ -26,6 +26,7 @@ import {
   addEventToCalendarList as addEventToCalList,
   removeEventFromCalendarList as removeEventFromCalList,
   moveEventBetweenCalendarLists,
+  updateEventRefViewKey as updateEventRefViewKeyOnList,
   createCalendar,
 } from "../common/calendarList";
 import { getUserPublicKey, publishDeletionEvent } from "../common/nostr";
@@ -95,6 +96,12 @@ interface CalendarListsState {
     targetCalendarId: string,
     eventCoordinate: string,
     eventRef: string[],
+  ) => Promise<void>;
+  updateEventRefViewKey: (
+    calendarId: string,
+    eventCoordinate: string,
+    newViewKey: string,
+    relayUrl?: string,
   ) => Promise<void>;
   getVisibleEventRefs: () => string[][];
   getAllEventIds: () => string[];
@@ -377,6 +384,37 @@ export const useCalendarLists = create<CalendarListsState>((set, get) => ({
         return { calendars: updated };
       });
     }
+  },
+
+  /**
+   * Replaces the stored view key of an event reference in a calendar and
+   * republishes the list. Used by key rotation (author updating their own
+   * ref) and access updates (recipient applying a rotated key). No-op if the
+   * calendar or the ref is not found.
+   */
+  updateEventRefViewKey: async (
+    calendarId,
+    eventCoordinate,
+    newViewKey,
+    relayUrl,
+  ) => {
+    const calendar = get().calendars.find((c) => c.id === calendarId);
+    if (!calendar) return;
+
+    const updated = await updateEventRefViewKeyOnList(
+      calendar,
+      eventCoordinate,
+      newViewKey,
+      relayUrl,
+    );
+
+    set((state) => {
+      const calendars = state.calendars.map((c) =>
+        c.id === calendarId ? updated : c,
+      );
+      saveCalendarsToStorage(calendars);
+      return { calendars };
+    });
   },
 
   /**

--- a/src/stores/events.ts
+++ b/src/stores/events.ts
@@ -41,6 +41,7 @@ import {
   removeSecureItem,
 } from "../common/localStorage";
 import { useCalendarLists } from "./calendarLists";
+import { useInaccessibleEvents } from "./inaccessibleEvents";
 import {
   findCalendarForEvent,
   getCalendarEventCoordinate,
@@ -186,6 +187,15 @@ const processPrivateEvent = (
  */
 const processedEventIds = new Set<string>();
 
+/**
+ * Clears an event's d-tag from the processed set so the next
+ * {@link fetchPrivateEvents} call re-fetches and re-decrypts it. Used after an
+ * access update rewrites the stored view key for an event already seen.
+ */
+export const resetProcessedEvent = (dTag: string) => {
+  processedEventIds.delete(dTag);
+};
+
 export const useTimeBasedEvents = create<{
   events: ICalendarEvent[];
   eventById: Record<string, ICalendarEvent>;
@@ -256,6 +266,10 @@ export const useTimeBasedEvents = create<{
     useNotifications.getState().removeNotifications(id);
   },
   resetPrivateEvents: () => {
+    // Drop fetch dedup + "no access" tracking so a newly logged-in user
+    // re-fetches and re-evaluates access for their own events.
+    processedEventIds.clear();
+    void useInaccessibleEvents.getState().clearCached();
     set(({ events }) => {
       const publicEvents = events.filter((evt) => !evt.isPrivateEvent);
       saveEventsToStorage([]);
@@ -390,17 +404,33 @@ export const useTimeBasedEvents = create<{
         }
         const meta = dTag ? viewKeyMap.get(dTag) : undefined;
         if (meta) {
-          if (meta.viewKey) {
-            const decrypted = viewPrivateEvent(event, meta.viewKey);
-            if (decrypted) {
-              processPrivateEvent(
-                decrypted,
-                timeRange,
-                meta.viewKey,
-                meta.calendarId,
-                meta.relayUrl,
-              );
-            }
+          const coordinate = `${event.kind}:${event.pubkey}:${dTag}`;
+          const decrypted = meta.viewKey
+            ? viewPrivateEvent(event, meta.viewKey)
+            : null;
+          if (decrypted) {
+            processPrivateEvent(
+              decrypted,
+              timeRange,
+              meta.viewKey,
+              meta.calendarId,
+              meta.relayUrl,
+            );
+            // Regained/has access — drop any stale "no access" record.
+            useInaccessibleEvents.getState().remove(coordinate);
+          } else {
+            // Could not decrypt with the stored key (missing key or the author
+            // rotated it). Record it so the user can request access via the
+            // "Events Without Access" page instead of the event silently
+            // disappearing.
+            useInaccessibleEvents.getState().record({
+              coordinate,
+              kind: event.kind,
+              authorPubkey: event.pubkey,
+              dTag,
+              calendarId: meta.calendarId,
+              relayHint: meta.relayUrl,
+            });
           }
           processedEventIds.add(dTag);
         }

--- a/src/stores/inaccessibleEvents.test.ts
+++ b/src/stores/inaccessibleEvents.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useInaccessibleEvents } from "./inaccessibleEvents";
+
+const makeEntry = (coordinate: string, dTag: string) => ({
+  coordinate,
+  kind: 32678,
+  authorPubkey: "author",
+  dTag,
+  calendarId: "cal-1",
+});
+
+describe("useInaccessibleEvents", () => {
+  beforeEach(() => {
+    useInaccessibleEvents.setState({ byCoordinate: {} });
+  });
+
+  it("records an inaccessible event keyed by coordinate", () => {
+    const { record } = useInaccessibleEvents.getState();
+    record(makeEntry("32678:author:a", "a"));
+
+    const entry =
+      useInaccessibleEvents.getState().byCoordinate["32678:author:a"];
+    expect(entry).toBeDefined();
+    expect(entry.dTag).toBe("a");
+    expect(entry.lastSeenAt).toBeGreaterThan(0);
+  });
+
+  it("deduplicates by coordinate, refreshing the existing entry", () => {
+    const { record } = useInaccessibleEvents.getState();
+    record(makeEntry("32678:author:a", "a"));
+    record(makeEntry("32678:author:a", "a"));
+
+    expect(Object.keys(useInaccessibleEvents.getState().byCoordinate)).toEqual([
+      "32678:author:a",
+    ]);
+  });
+
+  it("removes an entry by coordinate", () => {
+    const { record, remove } = useInaccessibleEvents.getState();
+    record(makeEntry("32678:author:a", "a"));
+    remove("32678:author:a");
+
+    expect(
+      useInaccessibleEvents.getState().byCoordinate["32678:author:a"],
+    ).toBeUndefined();
+  });
+
+  it("lists entries most-recently-seen first", () => {
+    const { record } = useInaccessibleEvents.getState();
+    record(makeEntry("32678:author:a", "a"));
+    // Force a strictly later lastSeenAt on the second entry.
+    useInaccessibleEvents.setState((state) => ({
+      byCoordinate: {
+        ...state.byCoordinate,
+        "32678:author:b": {
+          ...makeEntry("32678:author:b", "b"),
+          lastSeenAt: state.byCoordinate["32678:author:a"].lastSeenAt + 10,
+        },
+      },
+    }));
+
+    const list = useInaccessibleEvents.getState().list();
+    expect(list.map((e) => e.dTag)).toEqual(["b", "a"]);
+  });
+});

--- a/src/stores/inaccessibleEvents.ts
+++ b/src/stores/inaccessibleEvents.ts
@@ -1,0 +1,95 @@
+/**
+ * Inaccessible Events Store
+ *
+ * Tracks event references the client knows about (from a calendar list) but
+ * cannot currently decrypt — usually because the author rotated the view key
+ * and has not re-shared it with this user yet.
+ *
+ * These are surfaced on the "Events Without Access" page so the user can ask
+ * the author for access or remove the reference from their calendar. Entries
+ * are keyed by event coordinate and cleared automatically once the event
+ * decrypts successfully (e.g. after applying an access update).
+ *
+ * Persistence mirrors the other stores: secure storage on native, in-memory
+ * only on web (getSecureItem is a no-op there).
+ */
+
+import { create } from "zustand";
+import {
+  getSecureItem,
+  setSecureItem,
+  removeSecureItem,
+} from "../common/localStorage";
+import type { IInaccessibleEvent } from "../utils/calendarListTypes";
+
+const INACCESSIBLE_EVENTS_STORAGE_KEY = "cal:inaccessible_events";
+
+const persist = (events: Record<string, IInaccessibleEvent>) => {
+  setSecureItem(INACCESSIBLE_EVENTS_STORAGE_KEY, Object.values(events));
+};
+
+interface InaccessibleEventsState {
+  /** Map of event coordinate → inaccessible event entry. */
+  byCoordinate: Record<string, IInaccessibleEvent>;
+
+  loadCached: () => Promise<void>;
+  /** Records (or refreshes) an event the client could not decrypt. */
+  record: (event: Omit<IInaccessibleEvent, "lastSeenAt">) => void;
+  /** Removes an entry once access is regained or it is no longer relevant. */
+  remove: (coordinate: string) => void;
+  /** Returns all inaccessible events, most recently seen first. */
+  list: () => IInaccessibleEvent[];
+  clearCached: () => Promise<void>;
+}
+
+export const useInaccessibleEvents = create<InaccessibleEventsState>(
+  (set, get) => ({
+    byCoordinate: {},
+
+    loadCached: async () => {
+      const cached = await getSecureItem<IInaccessibleEvent[]>(
+        INACCESSIBLE_EVENTS_STORAGE_KEY,
+        [],
+      );
+      if (cached.length === 0) return;
+      const byCoordinate: Record<string, IInaccessibleEvent> = {};
+      cached.forEach((entry) => {
+        byCoordinate[entry.coordinate] = entry;
+      });
+      set({ byCoordinate });
+    },
+
+    record: (event) => {
+      set((state) => {
+        const byCoordinate = {
+          ...state.byCoordinate,
+          [event.coordinate]: {
+            ...event,
+            lastSeenAt: Math.floor(Date.now() / 1000),
+          },
+        };
+        persist(byCoordinate);
+        return { byCoordinate };
+      });
+    },
+
+    remove: (coordinate) => {
+      set((state) => {
+        if (!state.byCoordinate[coordinate]) return state;
+        const { [coordinate]: _removed, ...byCoordinate } = state.byCoordinate;
+        persist(byCoordinate);
+        return { byCoordinate };
+      });
+    },
+
+    list: () =>
+      Object.values(get().byCoordinate).sort(
+        (a, b) => b.lastSeenAt - a.lastSeenAt,
+      ),
+
+    clearCached: async () => {
+      await removeSecureItem(INACCESSIBLE_EVENTS_STORAGE_KEY);
+      set({ byCoordinate: {} });
+    },
+  }),
+);

--- a/src/stores/invitations.ts
+++ b/src/stores/invitations.ts
@@ -29,7 +29,8 @@ import {
 } from "../common/nostr";
 import { nostrEventToCalendar } from "../utils/parser";
 import { useCalendarLists } from "./calendarLists";
-import { useTimeBasedEvents } from "./events";
+import { useTimeBasedEvents, resetProcessedEvent } from "./events";
+import { useInaccessibleEvents } from "./inaccessibleEvents";
 import { useBookingRequests } from "./bookingRequests";
 import { buildEventRef } from "../utils/calendarListTypes";
 import type { IInvitation } from "../utils/calendarListTypes";
@@ -59,6 +60,7 @@ interface InvitationsState {
   fetchInvitations: () => void;
   stopInvitations: () => void;
   acceptInvitation: (giftWrapId: string, calendarId: string) => Promise<void>;
+  applyAccessUpdate: (giftWrapId: string) => Promise<void>;
   dismissInvitation: (giftWrapId: string) => void;
   clearCachedInvitations: () => Promise<void>;
 }
@@ -158,7 +160,14 @@ export const useInvitations = create<InvitationsState>((set, get) => ({
           const invitation = batch.find((inv) => inv.eventId === eventId);
           if (!invitation) return;
           const decrypted = viewPrivateEvent(event, invitation.viewKey);
-          if (!decrypted) return;
+          if (!decrypted) {
+            // The key carried by this gift wrap no longer decrypts the event
+            // (e.g. the author rotated it again). Flag it so the panel shows an
+            // "ask the author for access" state instead of looping on loading.
+            invitation.inaccessible = true;
+            return;
+          }
+          invitation.inaccessible = false;
           const parsed = nostrEventToCalendar(decrypted, "", {
             viewKey: invitation.viewKey,
             isPrivateEvent: true,
@@ -199,11 +208,66 @@ export const useInvitations = create<InvitationsState>((set, get) => ({
           useCalendarLists.getState().getAllEventIds(),
         );
 
-        // If already in a calendar, the event was added when the booking was
-        // submitted (with the pre-generated view key). Auto-approve the matching
-        // outgoing booking so the UI updates without waiting for the separate
-        // booking-response gift wrap.
+        // If the event is already in a calendar, this gift wrap is either a
+        // booking confirmation, a duplicate, or a *key rotation* — the author
+        // re-shared the same event under a new view key. Compare the stored
+        // key against the incoming one to tell them apart.
         if (existingEventIds.has(rumor.eventId)) {
+          const coordinate = `${rumor.kind}:${rumor.authorPubkey}:${rumor.eventId}`;
+          const calendars = useCalendarLists.getState().calendars;
+          let existingViewKey = "";
+          let owningCalendarId = "";
+          for (const cal of calendars) {
+            const ref = cal.eventRefs.find((r) => r[0] === coordinate);
+            if (ref) {
+              existingViewKey = ref[2] ?? "";
+              owningCalendarId = cal.id;
+              break;
+            }
+          }
+
+          // New key for an event we already hold → surface an "update access"
+          // notification the user can act on. De-dupe per (event, new key).
+          if (
+            existingViewKey &&
+            rumor.viewKey &&
+            existingViewKey !== rumor.viewKey &&
+            owningCalendarId
+          ) {
+            const updateKey = `access-update:${rumor.eventId}:${rumor.viewKey}`;
+            if (processedIds.has(updateKey)) return;
+            processedIds.add(updateKey);
+
+            const { invitations: currentInvitations } = get();
+            if (
+              currentInvitations.some(
+                (inv) =>
+                  inv.isAccessUpdate &&
+                  inv.eventId === rumor.eventId &&
+                  inv.viewKey === rumor.viewKey,
+              )
+            ) {
+              return;
+            }
+
+            pendingBuffer.push({
+              originalInvitationId: rumor.originalInvitationId,
+              giftWrapId: rumor.originalInvitationId,
+              eventId: rumor.eventId,
+              viewKey: rumor.viewKey,
+              relayHint: rumor.relayHint,
+              receivedAt: rumor.createdAt,
+              status: "pending",
+              pubkey: rumor.authorPubkey,
+              kind: rumor.kind,
+              isAccessUpdate: true,
+              calendarId: owningCalendarId,
+            });
+            return;
+          }
+
+          // Same key (or no stored key to compare): keep the existing booking
+          // auto-approval behavior and ignore otherwise.
           useBookingRequests
             .getState()
             .markOutgoingApprovedByDTag(rumor.eventId, rumor.viewKey);
@@ -295,6 +359,46 @@ export const useInvitations = create<InvitationsState>((set, get) => ({
     }
 
     // Remove from invitations
+    set((state) => {
+      const updated = state.invitations.filter(
+        (i) => i.giftWrapId !== giftWrapId,
+      );
+      const unreadCount = updated.filter((i) => i.status === "pending").length;
+      saveInvitationsToStorage(updated);
+      return { invitations: updated, unreadCount };
+    });
+  },
+
+  /**
+   * Applies a received access update: the author rotated this event's view key
+   * and re-shared it. Rewrites the stored key on the existing calendar
+   * reference, then forces a re-fetch so the event decrypts with the new key.
+   */
+  applyAccessUpdate: async (giftWrapId) => {
+    const { invitations } = get();
+    const invitation = invitations.find(
+      (i) => i.giftWrapId === giftWrapId && i.isAccessUpdate,
+    );
+    if (!invitation || !invitation.calendarId) return;
+
+    const coordinate = `${invitation.kind}:${invitation.pubkey}:${invitation.eventId}`;
+
+    // Swap in the new view key on the existing calendar reference.
+    await useCalendarLists
+      .getState()
+      .updateEventRefViewKey(
+        invitation.calendarId,
+        coordinate,
+        invitation.viewKey,
+        invitation.relayHint,
+      );
+
+    // Drop dedup + "no access" state, then re-fetch so the event decrypts
+    // with the rotated key.
+    resetProcessedEvent(invitation.eventId);
+    useInaccessibleEvents.getState().remove(coordinate);
+    useTimeBasedEvents.getState().fetchPrivateEvents();
+
     set((state) => {
       const updated = state.invitations.filter(
         (i) => i.giftWrapId !== giftWrapId,

--- a/src/stores/user.ts
+++ b/src/stores/user.ts
@@ -13,6 +13,7 @@ import { cancelAllNotifications } from "../utils/notifications";
 import { defaultRelays, fetchRelayList } from "../common/nostr";
 import { useRelayStore } from "./relays";
 import { useCalendarLists } from "./calendarLists";
+import { useInaccessibleEvents } from "./inaccessibleEvents";
 import { useInvitations } from "./invitations";
 import { useBookingRequests } from "./bookingRequests";
 import { useSchedulingPages } from "./schedulingPages";
@@ -75,6 +76,7 @@ export const useUser = create<{
     await useCalendarLists.getState().clearCachedCalendars();
     logger.log("logout: cached calendars cleared");
     await useInvitations.getState().clearCachedInvitations();
+    await useInaccessibleEvents.getState().clearCached();
     await useBookingRequests.getState().clearCached();
     await useSchedulingPages.getState().clearCachedPages();
     // Clear background worker keys
@@ -121,6 +123,7 @@ const onUserChange = async () => {
       logger.log("onUserChange: loading cached calendars and invitations");
       useCalendarLists.getState().loadCachedCalendars();
       useTimeBasedEvents.getState().loadCachedEvents();
+      useInaccessibleEvents.getState().loadCached();
       logger.log("onUserChange: fetching relay list");
       const relays = await fetchRelayList(cachedUser.pubkey);
       const userRelays = relays.length > 0 ? relays : defaultRelays;

--- a/src/utils/calendarListTypes.test.ts
+++ b/src/utils/calendarListTypes.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { parseEventRef, buildEventRef } from "./calendarListTypes";
+import {
+  parseEventRef,
+  buildEventRef,
+  replaceEventRefViewKey,
+  resolveRotationRecipients,
+} from "./calendarListTypes";
 
 describe("parseEventRef", () => {
   it("parses an event ref correctly", () => {
@@ -74,5 +79,98 @@ describe("buildEventRef", () => {
     const parsed = parseEventRef(ref);
 
     expect(parsed).toEqual({ ...original, relayUrl: "" });
+  });
+});
+
+describe("replaceEventRefViewKey", () => {
+  const coordA = "32678:author:event-a";
+  const coordB = "32678:author:event-b";
+
+  it("replaces the view key of the matching ref only", () => {
+    const refs = [
+      [coordA, "wss://relay.a", "nsec1old"],
+      [coordB, "wss://relay.b", "nsec1other"],
+    ];
+
+    const result = replaceEventRefViewKey(refs, coordA, "nsec1new");
+
+    expect(result[0]).toEqual([coordA, "wss://relay.a", "nsec1new"]);
+    // Other refs are untouched.
+    expect(result[1]).toEqual([coordB, "wss://relay.b", "nsec1other"]);
+  });
+
+  it("updates the relay hint when one is supplied", () => {
+    const refs = [[coordA, "wss://relay.a", "nsec1old"]];
+
+    const result = replaceEventRefViewKey(
+      refs,
+      coordA,
+      "nsec1new",
+      "wss://relay.new",
+    );
+
+    expect(result[0]).toEqual([coordA, "wss://relay.new", "nsec1new"]);
+  });
+
+  it("keeps the original array contents when no ref matches", () => {
+    const refs = [[coordA, "wss://relay.a", "nsec1old"]];
+
+    const result = replaceEventRefViewKey(refs, coordB, "nsec1new");
+
+    expect(result).toEqual(refs);
+  });
+
+  it("round-trips: rotated ref re-parses with the new key", () => {
+    const refs = [
+      buildEventRef({
+        kind: 32678,
+        authorPubkey: "author",
+        eventDTag: "event-a",
+        relayUrl: "wss://relay.a",
+        viewKey: "nsec1old",
+      }),
+    ];
+
+    const rotated = replaceEventRefViewKey(refs, coordA, "nsec1new");
+    const parsed = parseEventRef(rotated[0]);
+
+    expect(parsed.viewKey).toBe("nsec1new");
+    expect(parsed.relayUrl).toBe("wss://relay.a");
+  });
+});
+
+describe("resolveRotationRecipients", () => {
+  it("returns invited participants only when responders are excluded", () => {
+    const recipients = resolveRotationRecipients({
+      invitedParticipants: ["alice", "bob"],
+      rsvpResponders: ["carol"],
+      includeRsvpResponders: false,
+      selfPubkey: "me",
+    });
+
+    expect(recipients.sort()).toEqual(["alice", "bob"]);
+  });
+
+  it("unions invited participants and responders when included", () => {
+    const recipients = resolveRotationRecipients({
+      invitedParticipants: ["alice", "bob"],
+      rsvpResponders: ["carol", "bob"],
+      includeRsvpResponders: true,
+      selfPubkey: "me",
+    });
+
+    expect(recipients.sort()).toEqual(["alice", "bob", "carol"]);
+  });
+
+  it("always excludes the author's own pubkey", () => {
+    const recipients = resolveRotationRecipients({
+      invitedParticipants: ["alice", "me"],
+      rsvpResponders: ["me", "carol"],
+      includeRsvpResponders: true,
+      selfPubkey: "me",
+    });
+
+    expect(recipients).not.toContain("me");
+    expect(recipients.sort()).toEqual(["alice", "carol"]);
   });
 });

--- a/src/utils/calendarListTypes.test.ts
+++ b/src/utils/calendarListTypes.test.ts
@@ -4,6 +4,8 @@ import {
   buildEventRef,
   replaceEventRefViewKey,
   resolveRotationRecipients,
+  getRemovedParticipants,
+  resolveRemovalRekeyRecipients,
 } from "./calendarListTypes";
 
 describe("parseEventRef", () => {
@@ -172,5 +174,65 @@ describe("resolveRotationRecipients", () => {
 
     expect(recipients).not.toContain("me");
     expect(recipients.sort()).toEqual(["alice", "carol"]);
+  });
+});
+
+describe("getRemovedParticipants", () => {
+  it("returns participants present before but not after", () => {
+    const removed = getRemovedParticipants(
+      ["alice", "bob", "carol"],
+      ["alice", "carol"],
+      "me",
+    );
+    expect(removed).toEqual(["bob"]);
+  });
+
+  it("never counts the author as removed", () => {
+    const removed = getRemovedParticipants(["me", "alice"], ["alice"], "me");
+    expect(removed).toEqual([]);
+  });
+
+  it("compares case-insensitively", () => {
+    const removed = getRemovedParticipants(["AbC", "DeF"], ["abc"], "me");
+    expect(removed).toEqual(["def"]);
+  });
+
+  it("returns empty when nobody was removed", () => {
+    const removed = getRemovedParticipants(["alice"], ["alice", "bob"], "me");
+    expect(removed).toEqual([]);
+  });
+});
+
+describe("resolveRemovalRekeyRecipients", () => {
+  it("keeps remaining invited and responders, drops the removed person", () => {
+    const recipients = resolveRemovalRekeyRecipients({
+      remainingParticipants: ["bob"],
+      rsvpResponders: ["carol"],
+      removedParticipants: ["alice"],
+      selfPubkey: "me",
+    });
+    expect(recipients.sort()).toEqual(["bob", "carol"]);
+  });
+
+  it("excludes a removed participant even if they also RSVP'd", () => {
+    const recipients = resolveRemovalRekeyRecipients({
+      remainingParticipants: ["bob"],
+      rsvpResponders: ["alice", "carol"],
+      removedParticipants: ["alice"],
+      selfPubkey: "me",
+    });
+    expect(recipients).not.toContain("alice");
+    expect(recipients.sort()).toEqual(["bob", "carol"]);
+  });
+
+  it("excludes the author and de-duplicates across both sources", () => {
+    const recipients = resolveRemovalRekeyRecipients({
+      remainingParticipants: ["bob", "me"],
+      rsvpResponders: ["bob", "carol"],
+      removedParticipants: [],
+      selfPubkey: "me",
+    });
+    expect(recipients).not.toContain("me");
+    expect(recipients.sort()).toEqual(["bob", "carol"]);
   });
 });

--- a/src/utils/calendarListTypes.ts
+++ b/src/utils/calendarListTypes.ts
@@ -75,6 +75,45 @@ export interface IInvitation {
   receivedAt: number;
   /** Current status of the invitation */
   status: "pending" | "accepted" | "dismissed";
+  /**
+   * True when this entry is an access update rather than a fresh invitation:
+   * the event is already in one of the user's calendars but the author has
+   * rotated the view key and re-shared it. Accepting it updates the stored
+   * view key instead of adding a new event.
+   */
+  isAccessUpdate?: boolean;
+  /** For access updates: the calendar list that already holds this event. */
+  calendarId?: string;
+  /**
+   * True when the referenced event could not be decrypted with the view key
+   * carried by this gift wrap (e.g. the author rotated the key after sending).
+   * The panel renders a "ask the author for access" state instead of looping
+   * on "loading…" forever.
+   */
+  inaccessible?: boolean;
+}
+
+/**
+ * An event reference the client knows about (from a calendar list) but cannot
+ * currently decrypt — typically because the author rotated the view key and
+ * has not (yet) re-shared it with this user. Surfaced on the "Events Without
+ * Access" page so the user can ask the author for access or remove it.
+ */
+export interface IInaccessibleEvent {
+  /** Canonical coordinate "{kind}:{authorPubkey}:{eventDTag}". */
+  coordinate: string;
+  /** Nostr event kind of the referenced event. */
+  kind: number;
+  /** Pubkey of the event's author (who can grant access). */
+  authorPubkey: string;
+  /** The event's d-tag identifier (shown to the user). */
+  dTag: string;
+  /** The calendar list id that holds this reference. */
+  calendarId: string;
+  /** Relay hint where the event was published, if known. */
+  relayHint?: string;
+  /** When this event was last seen as undecryptable (unix seconds). */
+  lastSeenAt: number;
 }
 
 /** Default color for newly created calendars */
@@ -151,4 +190,49 @@ export function findCalendarForEvent(
   return calendars.find((calendar) =>
     calendar.eventRefs.some((ref) => ref[0] === coordinate),
   );
+}
+
+/**
+ * Returns a new event-refs array with the view key (and optionally relay hint)
+ * of the ref matching `coordinate` replaced. All other refs are returned
+ * unchanged. If no ref matches, the original array is returned unchanged.
+ *
+ * Used by key rotation (author updating their own ref) and by access updates
+ * (recipient receiving a rotated key). Kept pure so it can be unit-tested
+ * without touching relays.
+ */
+export function replaceEventRefViewKey(
+  eventRefs: string[][],
+  coordinate: string,
+  newViewKey: string,
+  relayUrl?: string,
+): string[][] {
+  return eventRefs.map((ref) =>
+    ref[0] === coordinate
+      ? [ref[0], relayUrl ?? ref[1] ?? "", newViewKey]
+      : ref,
+  );
+}
+
+/**
+ * Resolves the set of recipients that should receive a rotated view key.
+ *
+ * Always includes the invited participants. When `includeRsvpResponders` is
+ * true, RSVP responders are added too (the issue lets the author choose
+ * "invited" vs "invited + responders"). The author's own pubkey is always
+ * excluded — the author updates their own calendar ref directly rather than
+ * gift-wrapping a key to themselves.
+ */
+export function resolveRotationRecipients(params: {
+  invitedParticipants: string[];
+  rsvpResponders: string[];
+  includeRsvpResponders: boolean;
+  selfPubkey: string;
+}): string[] {
+  const recipients = new Set<string>(params.invitedParticipants);
+  if (params.includeRsvpResponders) {
+    params.rsvpResponders.forEach((pubkey) => recipients.add(pubkey));
+  }
+  recipients.delete(params.selfPubkey);
+  return [...recipients];
 }

--- a/src/utils/calendarListTypes.ts
+++ b/src/utils/calendarListTypes.ts
@@ -236,3 +236,55 @@ export function resolveRotationRecipients(params: {
   recipients.delete(params.selfPubkey);
   return [...recipients];
 }
+
+/**
+ * Diffs the previous participant list against the current one to find who was
+ * removed. Comparison is case-insensitive (pubkeys may arrive as mixed-case
+ * npub-decoded hex) and the author's own pubkey is never counted as removed.
+ */
+export function getRemovedParticipants(
+  previousParticipants: string[],
+  currentParticipants: string[],
+  selfPubkey: string,
+): string[] {
+  const self = selfPubkey.toLowerCase();
+  const current = new Set(
+    currentParticipants.map((pubkey) => pubkey.toLowerCase()),
+  );
+  const removed = new Set<string>();
+  for (const pubkey of previousParticipants) {
+    const normalized = pubkey.toLowerCase();
+    if (normalized === self) continue;
+    if (!current.has(normalized)) removed.add(normalized);
+  }
+  return [...removed];
+}
+
+/**
+ * Builds the recipient set for a key rotation triggered by removing a
+ * participant: everyone who should keep access — the remaining invited
+ * participants plus anyone who RSVP'd (e.g. link invitees) — minus the
+ * removed person(s) and the author. Comparison is case-insensitive.
+ */
+export function resolveRemovalRekeyRecipients(params: {
+  remainingParticipants: string[];
+  rsvpResponders: string[];
+  removedParticipants: string[];
+  selfPubkey: string;
+}): string[] {
+  const removed = new Set(
+    params.removedParticipants.map((pubkey) => pubkey.toLowerCase()),
+  );
+  const self = params.selfPubkey.toLowerCase();
+  const recipients = new Set<string>();
+  for (const pubkey of [
+    ...params.remainingParticipants,
+    ...params.rsvpResponders,
+  ]) {
+    const normalized = pubkey.toLowerCase();
+    if (normalized === self) continue;
+    if (removed.has(normalized)) continue;
+    recipients.add(normalized);
+  }
+  return [...recipients];
+}

--- a/src/utils/routingHelper.ts
+++ b/src/utils/routingHelper.ts
@@ -12,6 +12,7 @@ export enum ROUTES {
   DayCalendar = "/d/:year/:month/:day",
   MonthCalendar = "/m/:year/:monthNumber",
   Notifications = "/notifications",
+  EventsWithoutAccess = "/events-without-access",
   // Appointment Scheduling
   SchedulingPageCreate = "/schedule/create",
   SchedulingPageEdit = "/schedule/edit/:naddr",


### PR DESCRIPTION
Fixes #163. Removing a participant used to republish the event under the **same** view key, so the removed person kept decrypting it and kept receiving updates. Now removal actually revokes access.

**Stacked on #172** (event key rotation) — it reuses `rotatePrivateEventKey`, `resolveRotationRecipients`, the "Events Without Access" page, and the "update my calendar" flow from that PR. Merge #172 first; until then this PR's diff includes #172's commits.

## Behavior
- When an edit drops a participant from a private event, `editPrivateCalendarEvent` **rotates the view key** instead of reusing it: re-encrypts under a fresh key and gift-wraps the new key only to those who should keep access.
- "Those who should keep access" = remaining invited participants **+ RSVP responders** (covers link-invitees), minus the removed person(s) and the author.
- Removed participant gets no new key, so their next fetch can't decrypt and the event shows up in their "Events Without Access" list. Remaining participants get the "update my calendar" prompt.
- No removal: behavior unchanged (reuse key, gift-wrap only newly-added participants).
- The edit dialog shows a warning when a removal will trigger a rotation.

## Notes
- RSVP responders are discovered via `fetchPrivateRSVPResponderPubkeys` (one `querySync` of kind 32069 `#a=coord`; responder identity is the plaintext event author, so no decryption needed). Only runs when a removal is detected.
- Handles the case where the same edit also moves the event to a different calendar (relocates the ref first so the in-place key update lands correctly).

## Testing
- Unit tests for the two new pure helpers (`getRemovedParticipants`, `resolveRemovalRekeyRecipients`).
- `vite build` passes; ESLint clean on `src`.
- Full `vitest`: 7 failures, all pre-existing on the base branch (EventStore, parser, formLink, notifications, availabilityHelper, invitations, sharedEventAddToCalendar) — no new failures, +7 new passing tests.
- Not exercised: live remove-to-revoke walkthrough against real relays (needs signer + relays).