### PR TITLE
Append .ci-{pr-number} to app ID in debug CI builds

### DIFF
--- a/.github/workflows/build-debug-apk.yml
+++ b/.github/workflows/build-debug-apk.yml
@@ -51,6 +51,10 @@ jobs:
           ref: ${{ fromJSON(steps.pr.outputs.result).sha }}
           fetch-depth: 0
 
+      - name: Set CI application ID
+        run: |
+          sed -i 's/applicationId "app\.formstr\.calendar"/applicationId "app.formstr.calendar.ci-${{ fromJSON(steps.pr.outputs.result).number }}"/' android/app/build.gradle
+
       # ✅ Node + pnpm setup
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -87,7 +91,7 @@ jobs:
         run: |
           chmod +x android/gradlew
           cd android
-          ./gradlew assembleDebug -PciSuffix=ci-${{ fromJSON(steps.pr.outputs.result).number }}
+          ./gradlew assembleDebug
 
       - name: Upload APK
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-debug-apk.yml
+++ b/.github/workflows/build-debug-apk.yml
@@ -87,7 +87,7 @@ jobs:
         run: |
           chmod +x android/gradlew
           cd android
-          ./gradlew assembleDebug -PciSuffix=ci-${{ fromJSON(steps.pr.outputs.result).number }}
+          ./gradlew assembleDebug -PciSuffix=ci_${{ fromJSON(steps.pr.outputs.result).number }}
 
       - name: Upload APK
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-debug-apk.yml
+++ b/.github/workflows/build-debug-apk.yml
@@ -87,7 +87,7 @@ jobs:
         run: |
           chmod +x android/gradlew
           cd android
-          ./gradlew assembleDebug
+          ./gradlew assembleDebug -PciSuffix=ci-${{ fromJSON(steps.pr.outputs.result).number }}
 
       - name: Upload APK
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-debug-apk.yml
+++ b/.github/workflows/build-debug-apk.yml
@@ -51,10 +51,6 @@ jobs:
           ref: ${{ fromJSON(steps.pr.outputs.result).sha }}
           fetch-depth: 0
 
-      - name: Set CI application ID
-        run: |
-          sed -i 's/applicationId "app\.formstr\.calendar"/applicationId "app.formstr.calendar.ci-${{ fromJSON(steps.pr.outputs.result).number }}"/' android/app/build.gradle
-
       # ✅ Node + pnpm setup
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -91,7 +87,7 @@ jobs:
         run: |
           chmod +x android/gradlew
           cd android
-          ./gradlew assembleDebug
+          ./gradlew assembleDebug -PciSuffix=ci-${{ fromJSON(steps.pr.outputs.result).number }}
 
       - name: Upload APK
         uses: actions/upload-artifact@v4

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -40,7 +40,8 @@ android {
     }
 
     defaultConfig {
-        applicationId "app.formstr.calendar"
+        def ciSuffix = project.hasProperty('ciSuffix') ? ".${project.property('ciSuffix')}" : ""
+        applicationId "app.formstr.calendar${ciSuffix}"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -40,8 +40,7 @@ android {
     }
 
     defaultConfig {
-        def ciSuffix = project.hasProperty('ciSuffix') ? ".${project.property('ciSuffix')}" : ""
-        applicationId "app.formstr.calendar${ciSuffix}"
+        applicationId "app.formstr.calendar"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
 


### PR DESCRIPTION
Passes -PciSuffix=ci-<PR> to Gradle so the installed APK gets a
distinct applicationId (e.g. app.formstr.calendar.ci-109), letting
it coexist with the production app on the same device.

https://claude.ai/code/session_01WcmkHSdewKUZxY5YxnUafL