### PR TITLE
calendar date parsing in local time

### DIFF
--- a/src/common/calendarEngine.test.ts
+++ b/src/common/calendarEngine.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { getEventSegmentForDay, layoutDayEvents } from "./calendarEngine";
+import {
+  getEventSegmentForDay,
+  getTimeFromCell,
+  layoutDayEvents,
+} from "./calendarEngine";
 import type { ICalendarEvent } from "../utils/types";
 
 const HOUR_MS = 60 * 60 * 1000;
@@ -207,5 +211,26 @@ describe("layoutDayEvents", () => {
 
     expect(positioned.top).toBe(0);
     expect(positioned.height).toBe(9 * 60);
+  });
+});
+
+describe("getTimeFromCell", () => {
+  it("treats YYYY-MM-DD cell dates as local calendar dates", () => {
+    const event = {
+      clientY: 15 * 60,
+      currentTarget: {
+        dataset: { date: "2026-06-22" },
+      },
+    } as unknown as React.MouseEvent<HTMLDivElement>;
+    const containerRef = {
+      current: {
+        getBoundingClientRect: () => ({ top: 0 }),
+      },
+    } as React.RefObject<HTMLDivElement>;
+
+    const timestamp = getTimeFromCell(event, containerRef);
+
+    expect(timestamp).toBe(atLocal(2026, 5, 22, 15));
+    expect(new Date(timestamp!).getDay()).toBe(1);
   });
 });

--- a/src/common/calendarEngine.ts
+++ b/src/common/calendarEngine.ts
@@ -167,12 +167,15 @@ export const getTimeFromCell = (
     const hour = Math.floor(clickY / 60) - offsetHours;
     const minute = Math.floor((clickY % 60) / 30) * 30; // Round to nearest 30 min
 
-    // Get date from the cell's data
-    const cellDate = new Date(event.currentTarget.dataset.date!);
+    // `YYYY-MM-DD` strings parse as UTC in JavaScript; split the parts so the
+    // clicked calendar date is interpreted in the user's local timezone.
+    const [year, month, day] = event.currentTarget.dataset.date!
+      .split("-")
+      .map(Number);
     const clickedDate = new Date(
-      cellDate.getFullYear(),
-      cellDate.getMonth(),
-      cellDate.getDate(),
+      year,
+      month - 1,
+      day,
       hour,
       minute,
     );

--- a/src/common/calendarEngine.ts
+++ b/src/common/calendarEngine.ts
@@ -169,16 +169,10 @@ export const getTimeFromCell = (
 
     // `YYYY-MM-DD` strings parse as UTC in JavaScript; split the parts so the
     // clicked calendar date is interpreted in the user's local timezone.
-    const [year, month, day] = event.currentTarget.dataset.date!
-      .split("-")
+    const [year, month, day] = event.currentTarget.dataset
+      .date!.split("-")
       .map(Number);
-    const clickedDate = new Date(
-      year,
-      month - 1,
-      day,
-      hour,
-      minute,
-    );
+    const clickedDate = new Date(year, month - 1, day, hour, minute);
 
     return clickedDate.getTime();
   }


### PR DESCRIPTION
Bug: when I click on a day to create an event, the event is set to happen on the previous day. So if I click on 3pm on Monday, the event is by default on Sunday at 3pm. 

The app was treating YYYY-MM-DD dates as UTC, which caused the date to show one day earlier in places like New York. I fixed it by creating the date using the local timezone instead. 