### PR TITLE
fix(form-filler): bind signer methods so private-form submit works

### DIFF
--- a/src/components/ContactFormDialog.tsx
+++ b/src/components/ContactFormDialog.tsx
@@ -17,12 +17,13 @@ import {
 import { alpha } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import CloseIcon from "@mui/icons-material/Close";
-import { FormsSigner, FormstrSDK, NormalizedForm } from "@formstr/sdk";
+import { FormstrSDK, NormalizedForm } from "@formstr/sdk";
 import { nip19 } from "nostr-tools";
 import { useIntl } from "react-intl";
 import { useUser } from "../stores/user";
 import { signerManager } from "../common/signer";
 import { fetchAttachedFormCached } from "../utils/formAttachment";
+import { toFormsSigner } from "../utils/toFormsSigner";
 import type { IFormAttachment } from "../utils/types";
 
 const CONTACT_FORM: IFormAttachment = {
@@ -131,12 +132,7 @@ export function ContactFormDialog({ open, onClose }: Props) {
     formEl.addEventListener("submit", onSubmitDom);
 
     signerManager.getSigner().then((signer) => {
-      const formsSigner: FormsSigner = {
-        signEvent: signer.signEvent.bind(signer),
-        getPublicKey: signer.getPublicKey.bind(signer),
-        nip44Decrypt: signer.nip44Decrypt!.bind(signer),
-        nip44Encrypt: signer.nip44Encrypt!.bind(signer),
-      };
+      const formsSigner = toFormsSigner(signer);
 
       sdk.attachSubmitListener(form as never, formsSigner, {
         onSuccess: () => {

--- a/src/components/FormFillerDialog.tsx
+++ b/src/components/FormFillerDialog.tsx
@@ -40,7 +40,7 @@ import { alpha } from "@mui/material/styles";
 import CloseIcon from "@mui/icons-material/Close";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
-import { FormsSigner, FormstrSDK, NormalizedForm } from "@formstr/sdk";
+import { FormstrSDK, NormalizedForm } from "@formstr/sdk";
 import dayjs from "dayjs";
 import type { Event as NostrEvent } from "nostr-tools";
 import { useIntl } from "react-intl";
@@ -53,6 +53,7 @@ import {
 import { useUser } from "../stores/user";
 import { fetchAttachedFormCached } from "../utils/formAttachment";
 import { buildFormstrUrl } from "../utils/formLink";
+import { toFormsSigner } from "../utils/toFormsSigner";
 
 type SdkOption = {
   id: string;
@@ -325,12 +326,7 @@ export function FormFillerDialog({
     };
     formEl.addEventListener("submit", onSubmitDom);
     signerManager.getSigner().then((signer) => {
-      const formsSigner: FormsSigner = {
-        signEvent: signer.signEvent,
-        getPublicKey: signer.getPublicKey,
-        nip44Decrypt: signer.nip44Decrypt!,
-        nip44Encrypt: signer.nip44Encrypt!,
-      };
+      const formsSigner = toFormsSigner(signer);
 
       sdk.attachSubmitListener(form as never, formsSigner, {
         onSuccess: ({ event }) => {

--- a/src/utils/toFormsSigner.test.ts
+++ b/src/utils/toFormsSigner.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import type { EventTemplate } from "nostr-tools";
+import type { ActiveSigner } from "@formstr/signer";
+import { toFormsSigner } from "./toFormsSigner";
+
+const sampleEvent: EventTemplate = {
+  kind: 1069,
+  tags: [],
+  content: "",
+  created_at: 0,
+};
+
+/**
+ * Mimics how `@formstr/signer` implements its signer classes: crypto/signing
+ * methods are plain (unbound) class methods that read a private field through
+ * `this`. Copying such a method as a bare reference detaches it from its
+ * instance, so calling it later throws "Cannot read private member ... from an
+ * object whose class did not declare it". `toFormsSigner` must guard against
+ * that by binding every method to the signer instance.
+ */
+class FakeSigner {
+  #secret: string;
+
+  constructor(secret: string) {
+    this.#secret = secret;
+  }
+
+  async getPublicKey(): Promise<string> {
+    return `pub:${this.#secret}`;
+  }
+
+  async signEvent(event: EventTemplate) {
+    return { ...event, sig: this.#secret } as never;
+  }
+
+  async nip44Encrypt(_peer: string, plaintext: string): Promise<string> {
+    return `enc(${this.#secret}):${plaintext}`;
+  }
+
+  async nip44Decrypt(_peer: string, ciphertext: string): Promise<string> {
+    return `dec(${this.#secret}):${ciphertext}`;
+  }
+}
+
+const makeSigner = () => new FakeSigner("s3cr3t") as unknown as ActiveSigner;
+
+describe("toFormsSigner", () => {
+  it("returns methods that stay bound to the signer when called detached", async () => {
+    const formsSigner = toFormsSigner(makeSigner());
+
+    // Detach the methods exactly the way the SDK does internally before calling.
+    const { getPublicKey, signEvent, nip44Encrypt, nip44Decrypt } = formsSigner;
+
+    await expect(getPublicKey()).resolves.toBe("pub:s3cr3t");
+    await expect(nip44Encrypt("peer", "hello")).resolves.toBe(
+      "enc(s3cr3t):hello",
+    );
+    await expect(nip44Decrypt("peer", "ct")).resolves.toBe("dec(s3cr3t):ct");
+    await expect(signEvent(sampleEvent)).resolves.toMatchObject({
+      sig: "s3cr3t",
+    });
+  });
+
+  it("preserves private-member access even when invoked on a plain object", async () => {
+    const formsSigner = toFormsSigner(makeSigner());
+
+    // Re-host the bound method on an unrelated object: binding must win over
+    // the call-site `this`, otherwise the private-field read throws.
+    const host = { nip44Encrypt: formsSigner.nip44Encrypt };
+    await expect(host.nip44Encrypt("peer", "x")).resolves.toBe("enc(s3cr3t):x");
+  });
+});

--- a/src/utils/toFormsSigner.ts
+++ b/src/utils/toFormsSigner.ts
@@ -1,0 +1,23 @@
+import type { FormsSigner } from "@formstr/sdk";
+import type { ActiveSigner } from "@formstr/signer";
+
+/**
+ * Adapts an `@formstr/signer` `ActiveSigner` into the `FormsSigner` shape the
+ * `@formstr/sdk` expects.
+ *
+ * The signer classes implement their crypto/signing methods as plain (unbound)
+ * class methods that read private fields (`#secretKey`, `#delegate`, `#plugin`)
+ * through `this`. The SDK calls those methods off the `FormsSigner` object —
+ * sometimes detached from it — so we MUST bind each method to the original
+ * signer instance. Copying bare method references instead detaches `this` and
+ * throws "Cannot read private member ... from an object whose class did not
+ * declare it" the moment the SDK invokes them.
+ */
+export function toFormsSigner(signer: ActiveSigner): FormsSigner {
+  return {
+    signEvent: signer.signEvent.bind(signer),
+    getPublicKey: signer.getPublicKey.bind(signer),
+    nip44Decrypt: signer.nip44Decrypt.bind(signer),
+    nip44Encrypt: signer.nip44Encrypt.bind(signer),
+  };
+}


### PR DESCRIPTION
## Problem

Filling a calendar-attached form while **logged in** fails on submit with:

```
[FormFillerDialog] submit failed TypeError: Cannot read private member #e
from an object whose class did not declare it
    at Object.nip44Encrypt (...)
    at UM.submit (...)   // SDK attachSubmitListener → submit
```

The encrypted (kind 1069) response is never published, so private/encrypted form submission is fully broken for every logged-in `@formstr/signer` account (local/ncryptsec, NIP-46 bunker, and Android NIP-55).

### Reproduction
1. Create a calendar event and attach a form.
2. Open that event while logged in with any `@formstr/signer` account.
3. Fill the form and press **Submit** → the error above; nothing is published.

## Root cause

`@formstr/signer`'s signer classes (`LocalSigner`, `BunkerSigner`, `AndroidSigner`) implement their crypto/signing methods as **plain, unbound class methods that read private fields through `this`**:

```js
// LocalSigner
async nip44Encrypt(peerPubkey, plaintext) {
  const key = nip44.v2.utils.getConversationKey(this.#secretKey, peerPubkey); // this.#secretKey
  return nip44.v2.encrypt(plaintext, key);
}
// BunkerSigner
nip44Encrypt(peerPubkey, plaintext) {
  return this.#delegate.nip44Encrypt(peerPubkey, plaintext);                  // this.#delegate
}
```

`FormFillerDialog` built its `FormsSigner` by copying those **bare method references** onto a fresh plain object:

```ts
const formsSigner: FormsSigner = {
  signEvent: signer.signEvent,
  getPublicKey: signer.getPublicKey,
  nip44Decrypt: signer.nip44Decrypt!,
  nip44Encrypt: signer.nip44Encrypt!,   // detached from its instance
};
```

The SDK's identified-submission path calls these off the passed object (`signer.nip44Encrypt(...)` then `signer.signEvent(...)`). With the methods detached, `this` is the plain `formsSigner` object, which has no `#secretKey` / `#delegate` private field — so the private-member read throws. The minified `#e` in the production error is that private field.

(The sibling `ContactFormDialog` already worked around this with inline `.bind(signer)`; `FormFillerDialog` did not.)

## Fix

Add a small `toFormsSigner` helper that **binds every method to the signer instance**, and route both dialogs through it:

```ts
export function toFormsSigner(signer: ActiveSigner): FormsSigner {
  return {
    signEvent: signer.signEvent.bind(signer),
    getPublicKey: signer.getPublicKey.bind(signer),
    nip44Decrypt: signer.nip44Decrypt.bind(signer),
    nip44Encrypt: signer.nip44Encrypt.bind(signer),
  };
}
```

- `FormFillerDialog` now uses it → bug fixed.
- `ContactFormDialog` now uses it too → the inline `.bind` duplication is removed and there is a single canonical way to build a `FormsSigner`.

## Test

`src/utils/toFormsSigner.test.ts` pins the behavior with a fake signer that reads a `#private` field through `this`:
- the returned methods keep working when **destructured/detached** and when **re-hosted on an unrelated object**;
- reverting the helper to bare references reproduces the exact `Cannot read private member` failure (verified via red/green).

## Verification

- `tsc --noEmit -p tsconfig.app.json` → exit 0
- `eslint` on changed files → 0 errors
- New regression tests pass (2/2); the rest of the suite is unchanged (the few failing specs — `formLink`, `rsvp`, `parser`, etc. — fail identically on `master` and are unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)