### PR TITLE
duplicate events now will be saved on relay

### DIFF
--- a/src/common/nostr.ts
+++ b/src/common/nostr.ts
@@ -12,7 +12,6 @@ import {
 import { normalizeURL } from "nostr-tools/utils";
 import { v4 as uuid } from "uuid";
 import { ICalendarEvent } from "../stores/events";
-import { TEMP_CALENDAR_ID } from "../stores/eventDetails";
 import { AbstractRelay } from "nostr-tools/abstract-relay";
 import * as nip59 from "./nip59";
 import {
@@ -38,6 +37,7 @@ import {
 } from "../utils/parser";
 import type { IBusyList } from "../utils/types";
 import { createLogger } from "../utils/logger";
+import { getPersistedCalendarEventId } from "../utils/calendarEventIdentity";
 
 export const defaultRelays = [
   "wss://relay.damus.io/",
@@ -421,7 +421,7 @@ export async function publishPrivateCalendarEvent(
     : generateSecretKey();
   const dTag =
     existingDTag ||
-    event.id ||
+    getPersistedCalendarEventId(event.id) ||
     bytesToHex(
       sha256(utf8ToBytes(`${JSON.stringify(event)}-${Date.now()}`)),
     ).substring(0, 30);
@@ -947,7 +947,7 @@ export const publishPublicCalendarEvent = async (
   onRelayComplete?: (url: string, success: boolean) => void,
 ) => {
   const pubKey = await getUserPublicKey();
-  const id = event.id && event.id !== TEMP_CALENDAR_ID ? event.id : uuid();
+  const id = getPersistedCalendarEventId(event.id) ?? uuid();
   const tags = [
     ["name", event.title],
     ["d", id],

--- a/src/components/CalendarEventEdit.tsx
+++ b/src/components/CalendarEventEdit.tsx
@@ -97,7 +97,6 @@ interface CalendarEventEditProps {
   event: ICalendarEvent | null;
   initialDateTime?: number;
   onClose: () => void;
-  onSave?: (event: ICalendarEvent) => void;
   mode?: "create" | "edit";
   display?: "modal" | "page";
 }
@@ -317,7 +316,6 @@ export function CalendarEventEdit({
   event: initialEvent,
   initialDateTime,
   onClose,
-  onSave,
   mode = "create",
   display = "modal",
 }: CalendarEventEditProps) {
@@ -709,15 +707,7 @@ export function CalendarEventEdit({
 
       // Persist preference so future events default to the user's last choice.
       setBusyListDefaultOptIn(publishBusy);
-      if (onSave) {
-        onSave(savedEvent);
-      }
-
-      // const allOk = getFailedRelays(relaysToPublish).length === 0;
-      // setProcessing(false);
-      // if (allOk) {
       handleClose();
-      // }
     } catch (e) {
       console.error(e instanceof Error ? e.message : "Unknown error");
       const failedRelays = getFailedRelays(relaysToPublish);

--- a/src/components/DuplicateEventPage.tsx
+++ b/src/components/DuplicateEventPage.tsx
@@ -133,7 +133,6 @@ export const DuplicateEventPage = () => {
             open={true}
             event={duplicatedEvent}
             onClose={() => navigate(-1)}
-            onSave={() => navigate(-1)}
             mode="create"
             display="page"
           />

--- a/src/components/EditEventPage.tsx
+++ b/src/components/EditEventPage.tsx
@@ -116,7 +116,6 @@ export const EditEventPage = () => {
             open={true}
             event={loadState.event}
             onClose={() => navigate(-1)}
-            onSave={() => navigate(-1)}
             mode="edit"
             display="page"
           />

--- a/src/utils/calendarEventIdentity.test.ts
+++ b/src/utils/calendarEventIdentity.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { TEMP_CALENDAR_ID } from "../stores/eventDetails";
+import { getPersistedCalendarEventId } from "./calendarEventIdentity";
+
+describe("getPersistedCalendarEventId", () => {
+  it("preserves the d-tag of an existing event", () => {
+    expect(getPersistedCalendarEventId("existing-d-tag")).toBe(
+      "existing-d-tag",
+    );
+  });
+
+  it("rejects unsaved event identities", () => {
+    expect(getPersistedCalendarEventId("")).toBeUndefined();
+    expect(getPersistedCalendarEventId(undefined)).toBeUndefined();
+    expect(getPersistedCalendarEventId(TEMP_CALENDAR_ID)).toBeUndefined();
+  });
+});

--- a/src/utils/calendarEventIdentity.ts
+++ b/src/utils/calendarEventIdentity.ts
@@ -1,0 +1,6 @@
+import { TEMP_CALENDAR_ID } from "../stores/eventDetails";
+export function getPersistedCalendarEventId(
+  eventId: string | undefined,
+): string | undefined {
+  return eventId && eventId !== TEMP_CALENDAR_ID ? eventId : undefined;
+}

--- a/src/utils/duplicateEvent.test.ts
+++ b/src/utils/duplicateEvent.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it, vi, afterEach } from "vitest";
 import { buildDuplicatedEventDraft } from "./duplicateEvent";
-import { TEMP_CALENDAR_ID } from "../stores/eventDetails";
 import { RSVPStatus, type ICalendarEvent } from "./types";
 
 function makeEvent(overrides: Partial<ICalendarEvent> = {}): ICalendarEvent {
@@ -56,7 +55,7 @@ describe("buildDuplicatedEventDraft", () => {
     expect(duplicated.participants).toEqual(["npub1participant"]);
     expect(duplicated.repeat.rrule).toBe("FREQ=WEEKLY");
 
-    expect(duplicated.id).toBe(TEMP_CALENDAR_ID);
+    expect(duplicated.id).toBe("");
     expect(duplicated.eventId).toBe("");
     expect(duplicated.createdAt).toBe(
       new Date("2026-04-28T12:30:00Z").valueOf(),
@@ -66,5 +65,15 @@ describe("buildDuplicatedEventDraft", () => {
     expect(duplicated.isInvitation).toBe(false);
     expect(duplicated.relayHint).toBeUndefined();
     expect(duplicated.rsvpResponses).toEqual([]);
+  });
+
+  it("does not reuse the source or temporary identity for a new event", () => {
+    const firstDraft = buildDuplicatedEventDraft(makeEvent());
+    const secondDraft = buildDuplicatedEventDraft(
+      makeEvent({ id: "Temp calendar id" }),
+    );
+
+    expect(firstDraft.id).toBe("");
+    expect(secondDraft.id).toBe("");
   });
 });

--- a/src/utils/duplicateEvent.ts
+++ b/src/utils/duplicateEvent.ts
@@ -1,4 +1,3 @@
-import { TEMP_CALENDAR_ID } from "../stores/eventDetails";
 import type { ICalendarEvent } from "./types";
 
 export function buildDuplicatedEventDraft(
@@ -6,7 +5,7 @@ export function buildDuplicatedEventDraft(
 ): ICalendarEvent {
   return {
     ...event,
-    id: TEMP_CALENDAR_ID,
+    id: "",
     eventId: "",
     createdAt: Date.now(),
     user: "",


### PR DESCRIPTION
This was BUG reported by the jorb on signal  

Fixed duplicate events by ensuring every copied event gets a new unique ID instead of reusing the temporary editor ID. This prevents duplicates from disappearing after app restarts or failing to appear when duplicating an already duplicated event. 